### PR TITLE
Second draft: Hard-coded profile card

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,6 @@
----
-title: Code of Conduct
-permalink: /code-of-conduct/
----
-
 # Contributor Code of Conduct
 
-All PDS Interop projects adhere to both [the Code Manifesto](http://codemanifesto.com) and [the Contributor Covenant](http://contributor-covenant.org)
+All PDS Interop projects adhere to [the Code Manifesto](http://codemanifesto.com) 
 as its guidelines for contributor and community interactions.
-
 
 For full details visit: [https://pdsinterop.org/code-of-conduct/](https://pdsinterop.org/code-of-conduct/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,3 @@
----
-title: Contributing
-permalink: /contributing/
----
-
 # Contributing to the PHP standalone Solid Server
 
 Thank you for your interest in contributing!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # Standalone PHP Solid Server
 
-> Standalone Solid Server written in PHP by PDS Interop
+[![PDS Interop][pdsinterop-shield]][pdsinterop-site]
+[![Project stage: Development][project-stage-badge: Development]][project-stage-page]
+[![License][license-shield]][license-link]
+[![Latest Version][version-shield]][version-link]
+[![standard-readme compliant][standard-readme-shield]][standard-readme-link]
+![Maintained][maintained-shield]
 
-## Solid Server
+_Standalone Solid Server written in PHP by PDS Interop_
+
+## Table of Contents
+
+<!-- toc -->
+<!-- tocstop -->
+
+## Background
 
 The Solid specifications defines what makes a "Solid Server". Parts of
 those specifications are still likely to change, but at the time of this writing,
@@ -20,29 +32,6 @@ they define:
 To read more about Solid, and which IETF and W3C specifications are used, visit: https://pdsinterop.org/solid-specs-overview/
 -->
 
-## Available Features
-
-Based on the specifications, the following features are available:
-
-1. User
-   - [ ] Authentication
-   - [ ] Identity
-   - [ ] Profiles
-2. Data storage
-   - [ ] Content representation
-   - [ ] Resource API
-     - [ ] HTTP REST API
-     - [ ] Websocket API
-3. Web Acces Control List
-   - [ ] Authorization (and Access Control)
-4. Social web apps
-   - [ ] Calendar
-   - [ ] Contacts
-   - [ ] Friends Lists (Followers, Following)
-   - [ ] Notifications
-
-The checkboxes show which features are available, and which ones are not.
-
 ### Installation
 
 To install the project, clone it from GitHub and install the PHP dependencies
@@ -59,28 +48,20 @@ At this point, the application is ready to run.
 
 The PHP Solid server can be run in several different ways.
 
-<!-- @TODO: Add local Dockerfile
+<!-- @TODO: Add local Dockerfile  -->
 
-The easiest is using the provided `Dockerfile`.
-
-If a different environment is desired, the application can be run with the
-Docker image of your choice.
-
-Lastly, the application can be run on a local environment, using Apache, NginX,
-or PHP's internal HTTP server. The latter is only advised in development.
- -->
-
-The application can be run with a Docker image of your choice or on a local environment, using Apache, NginX, or PHP's internal HTTP server. The latter is
+The application can be run with a Docker image of your choice or on a local
+environment, using Apache, NginX, or PHP's internal HTTP server. The latter is
 only advised in development.
+
+For security reasons, the server expects to run on HTTPS (also known as HTTP+TLS).
+
+To run insecure, set the environment variable `ENVIRONMENT` to `develop`. This
+will prohibit the application from running in production mode.
 
 <!--
    @TODO: Add single-button deploy scripts/config for Heroku, Glitch, and other
           popular playgrounds/developer oriented service providers.
--->
-<!--
-### Provided Dockerfile
-
-In the project root, run: `docker run`
 -->
 
 ### Docker images
@@ -91,7 +72,7 @@ to wherever it will be hosted by the Docker container.
 For instance:
 
 ```
-export PORT=80 &&          \
+export PORT=8080 &&        \
 docker run                 \
    --env "PORT=${PORT}"    \
    --expose "${PORT}"      \
@@ -100,7 +81,7 @@ docker run                 \
    --volume "$PWD:/app"    \
    -it                     \
    php:7.1                 \
-   php -S "localhost:${PORT}" -t /app/web/ /app/web/index.php
+   php --docroot /app/web/ --server "localhost:${PORT}" /app/web/index.php
 ```
 
 ### Local environment
@@ -151,18 +132,29 @@ If you discover any security related issues, please email <security@pdsinterop.o
 
 -->
 
-## Contributing
+## Available Features
 
-Contributions are welcomed. Read the [contribution guidelines](CONTRIBUTING.md) for
-details.
+Based on the specifications, the following features are available:
 
-## Change Log
+1. User
+   - [ ] Authentication
+   - [ ] Identity
+   - [ ] Profiles
+2. Data storage
+   - [ ] Content representation
+   - [ ] Resource API
+     - [ ] HTTP REST API
+     - [ ] Websocket API
+3. Web Acces Control List
+   - [ ] Authorization (and Access Control)
+4. Social web apps
+   - [ ] Calendar
+   - [ ] Contacts
+   - [ ] Friends Lists (Followers, Following)
+   - [ ] Notifications
 
-Please see [CHANGELOG](CHANGELOG.md) for details.
+The checkboxes show which features are available, and which ones are not.
 
-## License
-
-All code created by PDS Interop is licensed under the [MIT License][LICENSE].
 
 ## Development
 
@@ -210,3 +202,35 @@ The PHPUnit version to be used is the one installed as a `dev-` dependency via c
 $ ./vendor/bin/phpunit
 ```
 -->
+
+## Contributing
+
+Questions or feedback can be given by [opening an issue on GitHub](https://github.com/pdsinterop/flysystem-rdf/issues).
+
+All PDS Interop projects are open source and community-friendly. 
+Any contribution is welcome!
+For more details read the [contribution guidelines](contributing.md).
+
+All PDS Interop projects adhere to [the Code Manifesto](http://codemanifesto.com)
+as its [code-of-conduct](CODE_OF_CONDUCT.md). Contributors are expected to abide by its terms.
+
+There is [a list of all contributors on GitHub][contributors-page].
+
+For a list of changes see the [CHANGELOG](CHANGELOG.md) or the GitHub releases page.
+
+## License
+
+All code created by PDS Interop is licensed under the [MIT License][license-link].
+
+[contributors-page]:  https://github.com/pdsinterop/flysystem-rdf/contributors
+[license-link]: ./LICENSE
+[license-shield]: https://img.shields.io/github/license/pdsinterop/flysystem-rdf.svg
+[maintained-shield]: https://img.shields.io/maintenance/yes/2020
+[pdsinterop-shield]: https://img.shields.io/badge/-PDS%20Interop-gray.svg?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii01IC01IDExMCAxMTAiIGZpbGw9IiNGRkYiIHN0cm9rZS13aWR0aD0iMCI+CiAgICA8cGF0aCBkPSJNLTEgNTJoMTdhMzcuNSAzNC41IDAgMDAyNS41IDMxLjE1di0xMy43NWEyMC43NSAyMSAwIDAxOC41LTQwLjI1IDIwLjc1IDIxIDAgMDE4LjUgNDAuMjV2MTMuNzVhMzcgMzQuNSAwIDAwMjUuNS0zMS4xNWgxN2EyMiAyMS4xNSAwIDAxLTEwMiAweiIvPgogICAgPHBhdGggZD0iTSAxMDEgNDhhMi43NyAyLjY3IDAgMDAtMTAyIDBoIDE3YTIuOTcgMi44IDAgMDE2OCAweiIvPgo8L3N2Zz4K
+[pdsinterop-site]: https://pdsinterop.org/
+[project-stage-badge: Development]: https://img.shields.io/badge/Project%20Stage-Development-yellowgreen.svg
+[project-stage-page]: https://blog.pother.ca/project-stages/
+[standard-readme-link]: https://github.com/RichardLitt/standard-readme
+[standard-readme-shield]: https://img.shields.io/badge/readme%20style-standard-brightgreen.svg
+[version-link]: https://packagist.org/packages/pdsinterop/flysystem-rdf
+[version-shield]: https://img.shields.io/github/v/release/pdsinterop/flysystem-rdf?sort=semver

--- a/bin/serve-docker-dev.sh
+++ b/bin/serve-docker-dev.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Run a PHP development server in docker
+
+docker run                          \
+  -i                                \
+  --env 'ENVIRONMENT=development'   \
+  --expose 80                       \
+  --name php-solid-server           \
+  --network host                    \
+  --rm                              \
+  --volume "${PWD}:/app"            \
+  "php:${PHP_VERSION:-7.1}-alpine"  \
+  php                               \
+    --define 'log_errors=On'        \
+    --docroot /app/web/             \
+    --server '0.0.0.0:80'           \
+    /app/web/index.php

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,43 @@
 {
+    "autoload": {
+        "psr-4" :{
+            "Pdsinterop\\Solid\\": "src/"
+        }
+    },
     "config": {
+        "bin-dir": "./bin",
+        "platform": {
+            "php": "7.1.33",
+            "ext-dom": "0.0.0",
+            "ext-mbstring": "0.0.0"
+        },
         "sort-packages": true
     },
     "description": "Standalone Solid Server written in PHP by PDS Interop.",
     "license": "MIT",
     "name": "pdsinterop/solid-server",
     "require": {
-        "php": "^7.1",
+        "php": "~7.1",
         "ext-json": "*",
+        "ext-mbstring": "*",
         "ext-openssl": "*",
-        "defuse/php-encryption": "^2.2",
-        "easyrdf/easyrdf": "^0.9",
-        "laminas/laminas-diactoros": "^2.3",
-        "laminas/laminas-httphandlerrunner": "^1.2",
-        "league/container": "^3.3",
-        "league/oauth2-server": "^8.1",
-        "league/route": "^4.5",
-        "php-http/httplug": "^2.1"
+        "defuse/php-encryption":"^2.2",
+        "laminas/laminas-diactoros":" ^2.3",
+        "laminas/laminas-httphandlerrunner":"^1.2",
+        "league/container":"^3.3",
+        "league/flysystem":"^1.0.",
+        "league/oauth2-server":"^8.0",
+        "league/route":"^4.5",
+        "pdsinterop/flysystem-rdf":"^0.1",
+        "php-http/httplug":"^2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*"
     },
     "scripts": {
         "lint":"",
-        "serve":"php -S \"${HOST:-localhost}:${PORT:-80}\" -t web/ web/index.php",
+        "serve-dev":"ENVIRONMENT=development php -S \"${HOST:-localhost}:${PORT:-80}\" -t web/ web/index.php",
+        "serve-dev-docker":"bash ./bin/serve-docker-dev.sh",
         "test":"phpunit"
     },
     "type": "project"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.3'
+
+services:
+  solid_php:
+    command: "php --docroot /app/web/ --server 'localhost:80' /app/web/index.php"
+    container_name: solid-php-server
+    # environment variables can be passed from the host straight to a containers by not providing value
+    environment:
+      - ENVIRONMENT=development
+      - PHP_VERSION
+    ports:
+      - "${PORT:-80}:80"
+    image: "php:${PHP_VERSION:-7.1}"
+    network_mode: host
+    volumes:
+      - ".:/app"

--- a/docs/spec-compliance/server.md
+++ b/docs/spec-compliance/server.md
@@ -1,0 +1,27 @@
+# Server
+
+This document describes what the Solid specification demands from a server in
+general. Implementation details have been added describing if and how compliance
+has been reached.
+
+## Spec compliance
+
+- [x] _All http URIs MUST redirect to their https counterparts using a response with a 301 status code and a Location header._<br>
+  ![][ready] Implemented through the `Pdsinterop\Solid\Controller\HttpToHttpsController`.
+
+- [ ] _It SHOULD additionally implement the server part of HTTP/1.1 Caching to improve performance_<br>
+  ![][maybe] As caching can be added "in-front" of the server this is deemed low-priority.
+
+- [ ] _When a client does not provide valid credentials when requesting a resource that requires it, the data pod MUST send a response with a 401 status code (unless 404 is preferred for security reasons)._<br>
+  ![][later] This will need to be implemented as part of the OAuth, ACL, and protected documents parts.
+
+- [ ] _A Solid server MUST reject PUT, POST and PATCH requests without the Content-Type header with a status code of 400._<br>
+  ![][todo] This should be added in a similar fashion as the HTTPtheHTTPS mechanism. No need to continue routing if this criteria is not met.
+
+- [x] _Paths ending with a slash denote a container resource. the server MAY respond to requests for the latter URI with a 301 redirect to the former._<br>
+  ![][ready] Implemented through the `Pdsinterop\Solid\Controller\AddSlashToPathController`
+
+[later]: https://img.shields.io/badge/resolution-later-important.svg
+[maybe]: https://img.shields.io/badge/resolution-maybe%20later-yellow.svg
+[ready]: https://img.shields.io/badge/resolution-done-success.svg
+[todo]:  https://img.shields.io/badge/resolution-todo-critical.svg

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Pdsinterop\Solid\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+abstract class AbstractController
+{
+    ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    /** @var ResponseInterface */
+    private $response;
+
+    //////////////////////////// GETTERS AND SETTERS \\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    final public function getResponse() : ResponseInterface
+    {
+        return $this->response;
+    }
+
+    //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    public function __construct(ResponseInterface $response)
+    {
+        $this->response = $response;
+    }
+
+    abstract public function __invoke(ServerRequestInterface $request, array $args) : ResponseInterface;
+
+    final public function createRedirectResponse(string $url, int $status = 302) : ResponseInterface
+    {
+        return $this->response->withHeader('location', $url)->withStatus($status);
+    }
+
+    final public function createTextResponse(string $message, int $status = 200) : ResponseInterface
+    {
+        $body = $this->response->getBody();
+
+        $body->write($message);
+
+        return $this->response->withBody($body)->withStatus($status);
+    }
+}

--- a/src/Controller/AbstractRedirectController.php
+++ b/src/Controller/AbstractRedirectController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Pdsinterop\Solid\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+abstract class AbstractRedirectController extends AbstractController
+{
+    ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    /** @var array */
+    private $args;
+
+    /** @var ServerRequestInterface */
+    private $request;
+    //////////////////////////// GETTERS AND SETTERS \\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    /** @return string  */
+    final public function getPath() : string
+    {
+        $target = $this->request->getRequestTarget();
+
+        [$path, $query] = explode('?', $target);
+
+        return $path;
+    }
+
+    /** @return string */
+    final public function getQuery() : string
+    {
+        $target = $this->request->getRequestTarget();
+
+        [$url, $query] = explode('?', $target);
+
+        if (is_string($query)) {
+            $query .= '?' . $query;
+        }
+
+
+        return (string) $query;
+    }
+
+    abstract public function getTargetUrl(): string;
+
+    //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    final public function __invoke(ServerRequestInterface $request, array $args): ResponseInterface
+    {
+        $this->request = $request;
+        $this->args = $args;
+
+        return $this->createRedirectResponse($this->getTargetUrl());
+    }
+
+    ////////////////////////////// UTILITY METHODS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+}

--- a/src/Controller/AddSlashToPathController.php
+++ b/src/Controller/AddSlashToPathController.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Pdsinterop\Solid\Controller;
+
+class AddSlashToPathController extends AbstractRedirectController
+{
+    /** @return string */
+    public function getTargetUrl() : string
+    {
+        return $this->getPath() . '/' . $this->getQuery();
+    }
+}

--- a/src/Controller/HelloWorldController.php
+++ b/src/Controller/HelloWorldController.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace Pdsinterop\Solid\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class HelloWorldController extends AbstractController
+{
+    final public function __invoke(ServerRequestInterface $request, array $args): ResponseInterface
+    {
+        $response = $this->getResponse();
+
+        $response->getBody()->write('<h1>Hello, World!</h1>');
+
+        return $response;
+    }
+}

--- a/src/Controller/HttpToHttpsController.php
+++ b/src/Controller/HttpToHttpsController.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace Pdsinterop\Solid\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class HttpToHttpsController extends AbstractController
+{
+  final public function __invoke(ServerRequestInterface $request, array $args): ResponseInterface
+  {
+    $serverParams = $request->getServerParams();
+
+    if (isset($serverParams['HTTP_HOST']) === false) {
+      $message = 'Could not determine host name.' .
+        'The server\'s HTTP_HOST variable has not been set!';
+
+      $response = $this->createTextResponse($message, 500);
+    } else {
+      $url = 'https://' . $serverParams['HTTP_HOST'] . $request->getRequestTarget();
+
+      $response = $this->createRedirectResponse($url, 301);
+    }
+
+    return $response;
+  }
+}

--- a/src/Controller/Profile/CardController.php
+++ b/src/Controller/Profile/CardController.php
@@ -1,0 +1,146 @@
+<?php declare(strict_types=1);
+
+namespace Pdsinterop\Solid\Controller\Profile;
+
+use League\Flysystem\FilesystemInterface;
+use League\Route\Http\Exception\NotFoundException;
+use Pdsinterop\Rdf\Enum\Format;
+use Pdsinterop\Solid\Controller\AbstractController;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class CardController extends AbstractController
+{
+    ////////////////////////////// CLASS PROPERTIES \\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    /** @var FilesystemInterface $filesystem */
+    private $filesystem;
+
+    //////////////////////////// GETTERS AND SETTERS \\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    //////////////////////////////// PUBLIC API \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    /**
+     * CardController constructor.
+     *
+     * @param ResponseInterface $response
+     * @param FilesystemInterface $filesystem
+     */
+    final public function __construct(
+        ResponseInterface $response,
+        FilesystemInterface $filesystem
+    ) {
+        $this->filesystem = $filesystem;
+
+        parent::__construct($response);
+    }
+
+    /**
+     * @param ServerRequestInterface $request
+     * @param array $args
+     *
+     * @return ResponseInterface
+     *
+     * @throws NotFoundException
+     */
+    final public function __invoke(ServerRequestInterface $request, array $args): ResponseInterface
+    {
+        $extension = '.ttl';
+
+        if (array_key_exists('extension', $args)) {
+            $extension = $args['extension'];
+        }
+
+        $format = $this->getFormatForExtension($extension);
+
+        if (in_array($format, Format::keys()) === false) {
+            throw new NotFoundException($request->getRequestTarget());
+        }
+
+        $contentType = $this->getContentTypeForFormat($format);
+
+        // @FIXME: Target file is hard-coded for not, replace with path from $request->getRequestTarget()
+        $filePath = '/foaf.rdf';
+
+        /** @noinspection PhpUndefinedMethodInspection */ // Method `readRdf` is defined by plugin
+        $content = $this->filesystem->readRdf($filePath, $format);
+
+        return $this->createTextResponse($content)->withHeader('Content-Type', $contentType);
+    }
+
+    ////////////////////////////// UTILITY METHODS \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
+
+    /**
+     * @param string $format
+     *
+     * @return string
+     */
+    private function getContentTypeForFormat(string $format) : string
+    {
+        $contentType = '';
+
+        switch ($format) {
+            case Format::JSON_LD:
+                $contentType = 'application/ld+json';
+                break;
+
+            case Format::N_TRIPLES:
+                $contentType = 'application/n-triples';
+                break;
+
+            case Format::NOTATION_3:
+                $contentType = 'text/n3;charset=utf-8';
+                break;
+
+            case Format::RDF_XML:
+                $contentType = 'application/rdf+xml';
+                break;
+
+            case Format::TURTLE:
+                $contentType = 'text/turtle';
+                break;
+
+            default:
+                break;
+        }
+
+        return $contentType;
+    }
+
+    /**
+     * @param string $extension
+     *
+     * @return string
+     */
+    private function getFormatForExtension(string $extension) : string
+    {
+        $format = '';
+
+        switch ($extension) {
+            case '.jsonld':
+                $format = Format::JSON_LD;
+                break;
+
+            case '.nt':
+                $format = Format::N_TRIPLES;
+                break;
+
+            case '.n3':
+                $format = Format::NOTATION_3;
+                break;
+
+            case '.rdf':
+                $format = Format::RDF_XML;
+                break;
+
+            case '.ttl':
+                $format = Format::TURTLE;
+                break;
+
+            default:
+                break;
+        }
+
+        return $format;
+}
+}

--- a/src/Controller/Profile/ProfileController.php
+++ b/src/Controller/Profile/ProfileController.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Pdsinterop\Solid\Controller\Profile;
+
+use Pdsinterop\Solid\Controller\AbstractRedirectController;
+
+class ProfileController extends AbstractRedirectController
+{
+    /** @return string */
+    public function getTargetUrl() : string
+    {
+        return $this->getPath() . 'card' . $this->getQuery();
+    }
+}

--- a/tests/fixtures/foaf.rdf
+++ b/tests/fixtures/foaf.rdf
@@ -1,0 +1,41 @@
+<rdf:RDF
+    xmlns:admin="http://webns.net/mvcb/"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+>
+    <foaf:Person rdf:ID="me">
+        <foaf:depiction rdf:resource="https://www.gravatar.com/avatar/f8d7c4a4899736c59ec1e40c7021d477?s=1024"/>
+        <foaf:family_name>Peachey</foaf:family_name>
+        <foaf:givenname>Ben</foaf:givenname>
+        <foaf:homepage rdf:resource="https://pother.ca"/>
+        <foaf:knows>
+            <foaf:Person>
+                <foaf:name>Alice</foaf:name>
+                <foaf:mbox_sha1sum>9e9c84204ba63aa49a664273c5563c0cd78cc9ea</foaf:mbox_sha1sum>
+                <rdfs:seeAlso rdf:resource="http://example.org/alice"/>
+            </foaf:Person>
+        </foaf:knows>
+        <foaf:knows>
+            <foaf:Person>
+                <foaf:name>Bob</foaf:name>
+                <foaf:mbox_sha1sum>1a9daad476f0158b81bc66b7b27b438b4b4c19c0</foaf:mbox_sha1sum>
+                <rdfs:seeAlso rdf:resource="http://bob.example.org/i"/>
+            </foaf:Person>
+        </foaf:knows>
+        <foaf:mbox_sha1sum>012e360c88b2bf940e6a52de3e5bbf59ccbdada6</foaf:mbox_sha1sum>
+        <foaf:name>Ben Peachey</foaf:name>
+        <foaf:nick>Potherca</foaf:nick>
+        <foaf:phone rdf:resource="tel:0123456789"/>
+        <foaf:schoolHomepage rdf:resource="https://aki.artez.nl/"/>
+        <foaf:title>Mr.</foaf:title>
+        <foaf:workInfoHomepage rdf:resource="https://www.linkedin.com/in/benpeachey/"/>
+        <foaf:workplaceHomepage rdf:resource="https://pdsinterop.org/"/>
+    </foaf:Person>
+    <foaf:PersonalProfileDocument rdf:about="">
+        <foaf:maker rdf:resource="#me"/>
+        <foaf:primaryTopic rdf:resource="#me"/>
+        <admin:generatorAgent rdf:resource="http://www.ldodds.com/foaf/foaf-a-matic"/>
+        <admin:errorReportsTo rdf:resource="mailto:leigh@ldodds.com"/>
+    </foaf:PersonalProfileDocument>
+</rdf:RDF>

--- a/web/index.php
+++ b/web/index.php
@@ -12,6 +12,7 @@ use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
 use League\Container\Container;
 use League\Container\ReflectionContainer;
 use League\Route\Http\Exception as HttpException;
+use League\Route\Http\Exception\NotFoundException;
 use League\Route\Router;
 use League\Route\Strategy\ApplicationStrategy;
 use Pdsinterop\Solid\Controller\AddSlashToPathController;
@@ -85,7 +86,12 @@ try {
 } catch (HttpException $exception) {
     $status = $exception->getStatusCode();
 
-    $html = "<h1>Yeah, that's an error.</h1><p>{$exception->getMessage()} ({$status})</p>";
+    $message = 'Yeah, that\'s an error.';
+    if ($exception instanceof  NotFoundException) {
+        $message = 'No such page.';
+    }
+
+    $html = "<h1>{$message}</h1><p>{$exception->getMessage()} ({$status})</p>";
 
     if (getenv('ENVIRONMENT') === 'development') {
         $html .= "<pre>{$exception->getTraceAsString()}</pre>";

--- a/web/index.php
+++ b/web/index.php
@@ -4,22 +4,30 @@ namespace Pdsinterop\Solid;
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use Laminas\Diactoros\Response;
 use Laminas\Diactoros\Response\HtmlResponse;
+use Laminas\Diactoros\ServerRequestFactory;
+use Laminas\HttpHandlerRunner\Emitter\SapiEmitter;
+use League\Container\Container;
+use League\Container\ReflectionContainer;
+use League\Route\Http\Exception as HttpException;
+use League\Route\Router;
+use League\Route\Strategy\ApplicationStrategy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
 /*/ Create objects /*/
-$container = new \League\Container\Container();
-$emitter = new \Laminas\HttpHandlerRunner\Emitter\SapiEmitter();
-$request = \Laminas\Diactoros\ServerRequestFactory::fromGlobals(
+$container = new Container();
+$emitter = new SapiEmitter();
+$request = ServerRequestFactory::fromGlobals(
     $_SERVER, $_GET, $_POST, $_COOKIE, $_FILES
 );
-$strategy = new \League\Route\Strategy\ApplicationStrategy();
+$strategy = new ApplicationStrategy();
 
-$router = new \League\Route\Router();
+$router = new Router();
 
 /*/ Wire objects together /*/
-$container->delegate(new \League\Container\ReflectionContainer);
+$container->delegate(new ReflectionContainer());
 
 $strategy->setContainer($container);
 
@@ -27,14 +35,14 @@ $strategy->setContainer($container);
 $router->setStrategy($strategy);
 
 $router->map('GET', '/', function (ServerRequestInterface $request) : ResponseInterface {
-    $response = new \Laminas\Diactoros\Response;
+    $response = new Response();
     $response->getBody()->write('<h1>Hello, World!</h1>');
     return $response;
 });
 
 try {
     $response = $router->dispatch($request);
-} catch (\League\Route\Http\Exception $exception) {
+} catch (HttpException $exception) {
     $status = $exception->getStatusCode();
 
     $html = "<h1>Yeah, that's an error.</h1><p>{$exception->getMessage()} ({$status})</p>";


### PR DESCRIPTION
This merge request adds some further infrastructure and a first set up to show a (currently hard-coded) RDF profile in various formats.

The format serialization is provided by [the PDS Interop Flysystem RDF plugin](https://github.com/pdsinterop/flysystem-rdf/).

When the application is run locally, the profile lives at http://localhost/profile/card`. It does not yet have an HTML representation. The turtle format is shown by default, others can be shown by adding a file extension (for instance http://localhost/profile/card.jsonld will show the JSON-LD format). Content negotiation from the headers still needs to be added.


