### PR TITLE
Change flysystem-rdf dependency to dev-master as dev-dev does not exist.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "league/flysystem": "^1.0.",
         "league/oauth2-server": "^8.0",
         "league/route": "^4.5",
-        "pdsinterop/flysystem-rdf": "dev-dev",
+        "pdsinterop/flysystem-rdf": "dev-master",
         "pdsinterop/solid-auth": "dev-master",
         "pdsinterop/solid-crud": "dev-master",
         "php-http/httplug": "^2.1",


### PR DESCRIPTION
Currently the Travis build is failing because of version constraint conflicts:

```
 Problem 1

    - Installation request for pdsinterop/flysystem-rdf dev-dev -> satisfiable by pdsinterop/flysystem-rdf[dev-dev].

    - pdsinterop/solid-crud dev-master requires pdsinterop/flysystem-rdf dev-master -> satisfiable by pdsinterop/flysystem-rdf[dev-master].

    - Can only install one of: pdsinterop/flysystem-rdf[dev-master, dev-dev].

    - Installation request for pdsinterop/solid-crud dev-master -> satisfiable by pdsinterop/solid-crud[dev-master].

```

This MR changes the version constraint from `dev-dev` to `dev-master`, which should smooth things over.  