### PR TITLE
Feature link metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ The underlying functionality for these features is provided by:
    - [ ] Contacts
    - [ ] Friends Lists (Followers, Following)
    - [ ] Notifications
+5. Extra / Non-specification features
+   - [x] Solid [link-metadata] <sup>[crud]</sup> (since **v0.7**)
+
+[link-metadata]: https://github.com/pdsinterop/solid-link-metadata/
 
 ## Development
 

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
         "league/flysystem": "^1.1",
         "league/oauth2-server": "^8.1",
         "league/route": "^4.5",
-        "pdsinterop/flysystem-rdf": "^0.3",
-        "pdsinterop/solid-auth": "^0.6",
-        "pdsinterop/solid-crud": "^0.3",
+        "pdsinterop/flysystem-rdf": "^v0.4",
+        "pdsinterop/solid-auth": "^v0.6",
+        "pdsinterop/solid-crud": "^v0.5",
         "php-http/httplug": "^2.2",
         "phptal/phptal": "^1.5"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -1,4711 +1,4711 @@
 {
-  "_readme": [
-    "This file locks the dependencies of your project to a known state",
-    "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
-    "This file is @generated automatically"
-  ],
-  "content-hash": "a4762a4964238c355630cfe003f3286a",
-  "packages": [
-    {
-      "name": "arc/base",
-      "version": "2.1.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/Ariadne-CMS/arc-base.git",
-        "reference": "b643a1a360c5a596c862a79611946d2f0f7b1654"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/Ariadne-CMS/arc-base/zipball/b643a1a360c5a596c862a79611946d2f0f7b1654",
-        "reference": "b643a1a360c5a596c862a79611946d2f0f7b1654",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=5.6"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "5.1.*"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "arc\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1c35c7f70398f5f7b52d47f890cfdf6f",
+    "packages": [
         {
-          "name": "Auke van Slooten",
-          "email": "auke@muze.nl"
-        }
-      ],
-      "description": "Ariadne Component Library",
-      "homepage": "https://github.com/Ariadne-CMS/arc/wiki",
-      "keywords": [
-        "component",
-        "components"
-      ],
-      "support": {
-        "issues": "https://github.com/Ariadne-CMS/arc-base/issues",
-        "source": "https://github.com/Ariadne-CMS/arc-base/tree/master"
-      },
-      "time": "2016-01-28T14:35:55+00:00"
-    },
-    {
-      "name": "arc/web",
-      "version": "2.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/Ariadne-CMS/arc-web.git",
-        "reference": "954270d2142bea5364a8e69fd4c6ad870378ac79"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/Ariadne-CMS/arc-web/zipball/954270d2142bea5364a8e69fd4c6ad870378ac79",
-        "reference": "954270d2142bea5364a8e69fd4c6ad870378ac79",
-        "shasum": ""
-      },
-      "require": {
-        "arc/base": "~2.0",
-        "php": ">=5.6"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "5.1.*"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "arc\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Auke van Slooten",
-          "email": "auke@muze.nl"
-        }
-      ],
-      "description": "Ariadne Component Library: Web Components",
-      "homepage": "https://github.com/Ariadne-CMS/arc/wiki",
-      "keywords": [
-        "component",
-        "components"
-      ],
-      "support": {
-        "issues": "https://github.com/Ariadne-CMS/arc-web/issues",
-        "source": "https://github.com/Ariadne-CMS/arc-web/tree/master"
-      },
-      "time": "2016-01-27T22:30:38+00:00"
-    },
-    {
-      "name": "brick/math",
-      "version": "0.9.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/brick/math.git",
-        "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/brick/math/zipball/ca57d18f028f84f777b2168cd1911b0dee2343ae",
-        "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae",
-        "shasum": ""
-      },
-      "require": {
-        "ext-json": "*",
-        "php": "^7.1 || ^8.0"
-      },
-      "require-dev": {
-        "php-coveralls/php-coveralls": "^2.2",
-        "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.0",
-        "vimeo/psalm": "4.9.2"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Brick\\Math\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "description": "Arbitrary-precision arithmetic library",
-      "keywords": [
-        "Arbitrary-precision",
-        "BigInteger",
-        "BigRational",
-        "arithmetic",
-        "bigdecimal",
-        "bignum",
-        "brick",
-        "math"
-      ],
-      "support": {
-        "issues": "https://github.com/brick/math/issues",
-        "source": "https://github.com/brick/math/tree/0.9.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/BenMorel",
-          "type": "github"
+            "name": "arc/base",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ariadne-CMS/arc-base.git",
+                "reference": "b643a1a360c5a596c862a79611946d2f0f7b1654"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ariadne-CMS/arc-base/zipball/b643a1a360c5a596c862a79611946d2f0f7b1654",
+                "reference": "b643a1a360c5a596c862a79611946d2f0f7b1654",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "arc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Auke van Slooten",
+                    "email": "auke@muze.nl"
+                }
+            ],
+            "description": "Ariadne Component Library",
+            "homepage": "https://github.com/Ariadne-CMS/arc/wiki",
+            "keywords": [
+                "component",
+                "components"
+            ],
+            "support": {
+                "issues": "https://github.com/Ariadne-CMS/arc-base/issues",
+                "source": "https://github.com/Ariadne-CMS/arc-base/tree/master"
+            },
+            "time": "2016-01-28T14:35:55+00:00"
         },
         {
-          "url": "https://tidelift.com/funding/github/packagist/brick/math",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2021-08-15T20:50:18+00:00"
-    },
-    {
-      "name": "codercat/jwk-to-pem",
-      "version": "1.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/acodercat/php-jwk-to-pem.git",
-        "reference": "4b3cdcf5f87b9b074f132f763a6b7b82c7d3ff1d"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/acodercat/php-jwk-to-pem/zipball/4b3cdcf5f87b9b074f132f763a6b7b82c7d3ff1d",
-        "reference": "4b3cdcf5f87b9b074f132f763a6b7b82c7d3ff1d",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.1",
-        "phpseclib/phpseclib": "^3.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^7.0"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "CoderCat\\JWKToPEM\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "codercat",
-          "email": "1067302838@qq.com"
-        }
-      ],
-      "description": "Convert JWK to PEM format.",
-      "support": {
-        "issues": "https://github.com/acodercat/php-jwk-to-pem/issues",
-        "source": "https://github.com/acodercat/php-jwk-to-pem/tree/1.1"
-      },
-      "time": "2021-04-28T07:37:03+00:00"
-    },
-    {
-      "name": "defuse/php-encryption",
-      "version": "v2.3.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/defuse/php-encryption.git",
-        "reference": "77880488b9954b7884c25555c2a0ea9e7053f9d2"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/defuse/php-encryption/zipball/77880488b9954b7884c25555c2a0ea9e7053f9d2",
-        "reference": "77880488b9954b7884c25555c2a0ea9e7053f9d2",
-        "shasum": ""
-      },
-      "require": {
-        "ext-openssl": "*",
-        "paragonie/random_compat": ">= 2",
-        "php": ">=5.6.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^4|^5|^6|^7|^8|^9"
-      },
-      "bin": [
-        "bin/generate-defuse-key"
-      ],
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Defuse\\Crypto\\": "src"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Taylor Hornby",
-          "email": "taylor@defuse.ca",
-          "homepage": "https://defuse.ca/"
+            "name": "arc/web",
+            "version": "2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ariadne-CMS/arc-web.git",
+                "reference": "954270d2142bea5364a8e69fd4c6ad870378ac79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ariadne-CMS/arc-web/zipball/954270d2142bea5364a8e69fd4c6ad870378ac79",
+                "reference": "954270d2142bea5364a8e69fd4c6ad870378ac79",
+                "shasum": ""
+            },
+            "require": {
+                "arc/base": "~2.0",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "arc\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Auke van Slooten",
+                    "email": "auke@muze.nl"
+                }
+            ],
+            "description": "Ariadne Component Library: Web Components",
+            "homepage": "https://github.com/Ariadne-CMS/arc/wiki",
+            "keywords": [
+                "component",
+                "components"
+            ],
+            "support": {
+                "issues": "https://github.com/Ariadne-CMS/arc-web/issues",
+                "source": "https://github.com/Ariadne-CMS/arc-web/tree/master"
+            },
+            "time": "2016-01-27T22:30:38+00:00"
         },
         {
-          "name": "Scott Arciszewski",
-          "email": "info@paragonie.com",
-          "homepage": "https://paragonie.com"
-        }
-      ],
-      "description": "Secure PHP Encryption Library",
-      "keywords": [
-        "aes",
-        "authenticated encryption",
-        "cipher",
-        "crypto",
-        "cryptography",
-        "encrypt",
-        "encryption",
-        "openssl",
-        "security",
-        "symmetric key cryptography"
-      ],
-      "support": {
-        "issues": "https://github.com/defuse/php-encryption/issues",
-        "source": "https://github.com/defuse/php-encryption/tree/v2.3.1"
-      },
-      "time": "2021-04-09T23:57:26+00:00"
-    },
-    {
-      "name": "easyrdf/easyrdf",
-      "version": "0.9.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/easyrdf/easyrdf.git",
-        "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/easyrdf/easyrdf/zipball/acd09dfe0555fbcfa254291e433c45fdd4652566",
-        "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566",
-        "shasum": ""
-      },
-      "require": {
-        "ext-mbstring": "*",
-        "ext-pcre": "*",
-        "php": ">=5.2.8"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "~3.5",
-        "sami/sami": "~1.4",
-        "squizlabs/php_codesniffer": "~1.4.3"
-      },
-      "suggest": {
-        "ml/json-ld": "~1.0"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-0": {
-          "EasyRdf_": "lib/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Nicholas Humfrey",
-          "email": "njh@aelius.com",
-          "homepage": "http://www.aelius.com/njh/",
-          "role": "Developer"
+            "name": "brick/math",
+            "version": "0.9.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/math.git",
+                "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/math/zipball/ca57d18f028f84f777b2168cd1911b0dee2343ae",
+                "reference": "ca57d18f028f84f777b2168cd1911b0dee2343ae",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^7.5.15 || ^8.5 || ^9.0",
+                "vimeo/psalm": "4.9.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\Math\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Arbitrary-precision arithmetic library",
+            "keywords": [
+                "Arbitrary-precision",
+                "BigInteger",
+                "BigRational",
+                "arithmetic",
+                "bigdecimal",
+                "bignum",
+                "brick",
+                "math"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/math/issues",
+                "source": "https://github.com/brick/math/tree/0.9.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/brick/math",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-15T20:50:18+00:00"
         },
         {
-          "name": "Alexey Zakhlestin",
-          "email": "indeyets@gmail.com",
-          "role": "Developer"
-        }
-      ],
-      "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
-      "homepage": "http://www.easyrdf.org/",
-      "keywords": [
-        "Linked Data",
-        "RDF",
-        "Semantic Web",
-        "Turtle",
-        "rdfa",
-        "sparql"
-      ],
-      "support": {
-        "forum": "http://groups.google.com/group/easyrdf/",
-        "irc": "irc://chat.freenode.net/easyrdf",
-        "issues": "http://github.com/njh/easyrdf/issues",
-        "source": "https://github.com/easyrdf/easyrdf/tree/0.9.1"
-      },
-      "time": "2015-02-27T09:45:49+00:00"
-    },
-    {
-      "name": "fgrosse/phpasn1",
-      "version": "v2.3.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/fgrosse/PHPASN1.git",
-        "reference": "6edcecb4df8b6881e79080d5e363dc8b90d4558c"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/fgrosse/PHPASN1/zipball/6edcecb4df8b6881e79080d5e363dc8b90d4558c",
-        "reference": "6edcecb4df8b6881e79080d5e363dc8b90d4558c",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.0.0"
-      },
-      "require-dev": {
-        "php-coveralls/php-coveralls": "~2.0",
-        "phpunit/phpunit": "^6.3 | ^7.0"
-      },
-      "suggest": {
-        "ext-bcmath": "BCmath is the fallback extension for big integer calculations",
-        "ext-curl": "For loading OID information from the web if they have not bee defined statically",
-        "ext-gmp": "GMP is the preferred extension for big integer calculations",
-        "phpseclib/bcmath_compat": "BCmath polyfill for servers where neither GMP nor BCmath is available"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.0.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "FG\\": "lib/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Friedrich Große",
-          "email": "friedrich.grosse@gmail.com",
-          "homepage": "https://github.com/FGrosse",
-          "role": "Author"
+            "name": "codercat/jwk-to-pem",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/acodercat/php-jwk-to-pem.git",
+                "reference": "4b3cdcf5f87b9b074f132f763a6b7b82c7d3ff1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/acodercat/php-jwk-to-pem/zipball/4b3cdcf5f87b9b074f132f763a6b7b82c7d3ff1d",
+                "reference": "4b3cdcf5f87b9b074f132f763a6b7b82c7d3ff1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "phpseclib/phpseclib": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "CoderCat\\JWKToPEM\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "codercat",
+                    "email": "1067302838@qq.com"
+                }
+            ],
+            "description": "Convert JWK to PEM format.",
+            "support": {
+                "issues": "https://github.com/acodercat/php-jwk-to-pem/issues",
+                "source": "https://github.com/acodercat/php-jwk-to-pem/tree/1.1"
+            },
+            "time": "2021-04-28T07:37:03+00:00"
         },
         {
-          "name": "All contributors",
-          "homepage": "https://github.com/FGrosse/PHPASN1/contributors"
-        }
-      ],
-      "description": "A PHP Framework that allows you to encode and decode arbitrary ASN.1 structures using the ITU-T X.690 Encoding Rules.",
-      "homepage": "https://github.com/FGrosse/PHPASN1",
-      "keywords": [
-        "DER",
-        "asn.1",
-        "asn1",
-        "ber",
-        "binary",
-        "decoding",
-        "encoding",
-        "x.509",
-        "x.690",
-        "x509",
-        "x690"
-      ],
-      "support": {
-        "issues": "https://github.com/fgrosse/PHPASN1/issues",
-        "source": "https://github.com/fgrosse/PHPASN1/tree/v2.3.1"
-      },
-      "time": "2021-12-09T20:59:31+00:00"
-    },
-    {
-      "name": "laminas/laminas-diactoros",
-      "version": "2.8.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/laminas/laminas-diactoros.git",
-        "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
-        "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
-        "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0"
-      },
-      "conflict": {
-        "phpspec/prophecy": "<1.9.0",
-        "zendframework/zend-diactoros": "*"
-      },
-      "provide": {
-        "psr/http-factory-implementation": "1.0",
-        "psr/http-message-implementation": "1.0"
-      },
-      "require-dev": {
-        "ext-curl": "*",
-        "ext-dom": "*",
-        "ext-gd": "*",
-        "ext-libxml": "*",
-        "http-interop/http-factory-tests": "^0.8.0",
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "php-http/psr7-integration-tests": "^1.1",
-        "phpspec/prophecy-phpunit": "^2.0",
-        "phpunit/phpunit": "^9.1",
-        "psalm/plugin-phpunit": "^0.14.0",
-        "vimeo/psalm": "^4.3"
-      },
-      "type": "library",
-      "extra": {
-        "laminas": {
-          "config-provider": "Laminas\\Diactoros\\ConfigProvider",
-          "module": "Laminas\\Diactoros"
-        }
-      },
-      "autoload": {
-        "files": [
-          "src/functions/create_uploaded_file.php",
-          "src/functions/marshal_headers_from_sapi.php",
-          "src/functions/marshal_method_from_sapi.php",
-          "src/functions/marshal_protocol_version_from_sapi.php",
-          "src/functions/marshal_uri_from_sapi.php",
-          "src/functions/normalize_server.php",
-          "src/functions/normalize_uploaded_files.php",
-          "src/functions/parse_cookie_header.php",
-          "src/functions/create_uploaded_file.legacy.php",
-          "src/functions/marshal_headers_from_sapi.legacy.php",
-          "src/functions/marshal_method_from_sapi.legacy.php",
-          "src/functions/marshal_protocol_version_from_sapi.legacy.php",
-          "src/functions/marshal_uri_from_sapi.legacy.php",
-          "src/functions/normalize_server.legacy.php",
-          "src/functions/normalize_uploaded_files.legacy.php",
-          "src/functions/parse_cookie_header.legacy.php"
-        ],
-        "psr-4": {
-          "Laminas\\Diactoros\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "description": "PSR HTTP Message implementations",
-      "homepage": "https://laminas.dev",
-      "keywords": [
-        "http",
-        "laminas",
-        "psr",
-        "psr-17",
-        "psr-7"
-      ],
-      "support": {
-        "chat": "https://laminas.dev/chat",
-        "docs": "https://docs.laminas.dev/laminas-diactoros/",
-        "forum": "https://discourse.laminas.dev",
-        "issues": "https://github.com/laminas/laminas-diactoros/issues",
-        "rss": "https://github.com/laminas/laminas-diactoros/releases.atom",
-        "source": "https://github.com/laminas/laminas-diactoros"
-      },
-      "funding": [
-        {
-          "url": "https://funding.communitybridge.org/projects/laminas-project",
-          "type": "community_bridge"
-        }
-      ],
-      "time": "2021-09-22T03:54:36+00:00"
-    },
-    {
-      "name": "laminas/laminas-httphandlerrunner",
-      "version": "1.5.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
-        "reference": "5f94e55d93f756e8ad07b9049aeb3d6d84582d0e"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/5f94e55d93f756e8ad07b9049aeb3d6d84582d0e",
-        "reference": "5f94e55d93f756e8ad07b9049aeb3d6d84582d0e",
-        "shasum": ""
-      },
-      "require": {
-        "laminas/laminas-zendframework-bridge": "^1.0",
-        "php": "^7.3 || ~8.0.0 || ~8.1.0",
-        "psr/http-message": "^1.0",
-        "psr/http-message-implementation": "^1.0",
-        "psr/http-server-handler": "^1.0"
-      },
-      "replace": {
-        "zendframework/zend-httphandlerrunner": "^1.1.0"
-      },
-      "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-diactoros": "^2.8.0",
-        "phpunit/phpunit": "^9.5.9",
-        "psalm/plugin-phpunit": "^0.16.1",
-        "vimeo/psalm": "^4.10.0"
-      },
-      "type": "library",
-      "extra": {
-        "laminas": {
-          "config-provider": "Laminas\\HttpHandlerRunner\\ConfigProvider"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Laminas\\HttpHandlerRunner\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "description": "Execute PSR-15 RequestHandlerInterface instances and emit responses they generate.",
-      "homepage": "https://laminas.dev",
-      "keywords": [
-        "components",
-        "laminas",
-        "mezzio",
-        "psr-15",
-        "psr-7"
-      ],
-      "support": {
-        "chat": "https://laminas.dev/chat",
-        "docs": "https://docs.laminas.dev/laminas-httphandlerrunner/",
-        "forum": "https://discourse.laminas.dev",
-        "issues": "https://github.com/laminas/laminas-httphandlerrunner/issues",
-        "rss": "https://github.com/laminas/laminas-httphandlerrunner/releases.atom",
-        "source": "https://github.com/laminas/laminas-httphandlerrunner"
-      },
-      "funding": [
-        {
-          "url": "https://funding.communitybridge.org/projects/laminas-project",
-          "type": "community_bridge"
-        }
-      ],
-      "time": "2021-09-22T09:17:54+00:00"
-    },
-    {
-      "name": "laminas/laminas-zendframework-bridge",
-      "version": "1.4.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-        "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-        "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3",
-        "psalm/plugin-phpunit": "^0.15.1",
-        "squizlabs/php_codesniffer": "^3.5",
-        "vimeo/psalm": "^4.6"
-      },
-      "type": "library",
-      "extra": {
-        "laminas": {
-          "module": "Laminas\\ZendFrameworkBridge"
-        }
-      },
-      "autoload": {
-        "files": [
-          "src/autoload.php"
-        ],
-        "psr-4": {
-          "Laminas\\ZendFrameworkBridge\\": "src//"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-      "keywords": [
-        "ZendFramework",
-        "autoloading",
-        "laminas",
-        "zf"
-      ],
-      "support": {
-        "forum": "https://discourse.laminas.dev/",
-        "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-        "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-        "source": "https://github.com/laminas/laminas-zendframework-bridge"
-      },
-      "funding": [
-        {
-          "url": "https://funding.communitybridge.org/projects/laminas-project",
-          "type": "community_bridge"
-        }
-      ],
-      "time": "2021-09-03T17:53:30+00:00"
-    },
-    {
-      "name": "lcobucci/jwt",
-      "version": "3.3.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/lcobucci/jwt.git",
-        "reference": "c1123697f6a2ec29162b82f170dd4a491f524773"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/lcobucci/jwt/zipball/c1123697f6a2ec29162b82f170dd4a491f524773",
-        "reference": "c1123697f6a2ec29162b82f170dd4a491f524773",
-        "shasum": ""
-      },
-      "require": {
-        "ext-mbstring": "*",
-        "ext-openssl": "*",
-        "php": "^5.6 || ^7.0"
-      },
-      "require-dev": {
-        "mikey179/vfsstream": "~1.5",
-        "phpmd/phpmd": "~2.2",
-        "phpunit/php-invoker": "~1.1",
-        "phpunit/phpunit": "^5.7 || ^7.3",
-        "squizlabs/php_codesniffer": "~2.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "3.1-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Lcobucci\\JWT\\": "src"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Luís Otávio Cobucci Oblonczyk",
-          "email": "lcobucci@gmail.com",
-          "role": "Developer"
-        }
-      ],
-      "description": "A simple library to work with JSON Web Token and JSON Web Signature",
-      "keywords": [
-        "JWS",
-        "jwt"
-      ],
-      "support": {
-        "issues": "https://github.com/lcobucci/jwt/issues",
-        "source": "https://github.com/lcobucci/jwt/tree/3.3.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/lcobucci",
-          "type": "github"
+            "name": "defuse/php-encryption",
+            "version": "v2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/defuse/php-encryption.git",
+                "reference": "77880488b9954b7884c25555c2a0ea9e7053f9d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/77880488b9954b7884c25555c2a0ea9e7053f9d2",
+                "reference": "77880488b9954b7884c25555c2a0ea9e7053f9d2",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "paragonie/random_compat": ">= 2",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4|^5|^6|^7|^8|^9"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Hornby",
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "Secure PHP Encryption Library",
+            "keywords": [
+                "aes",
+                "authenticated encryption",
+                "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
+                "encryption",
+                "openssl",
+                "security",
+                "symmetric key cryptography"
+            ],
+            "support": {
+                "issues": "https://github.com/defuse/php-encryption/issues",
+                "source": "https://github.com/defuse/php-encryption/tree/v2.3.1"
+            },
+            "time": "2021-04-09T23:57:26+00:00"
         },
         {
-          "url": "https://www.patreon.com/lcobucci",
-          "type": "patreon"
-        }
-      ],
-      "time": "2020-08-20T13:22:28+00:00"
-    },
-    {
-      "name": "league/container",
-      "version": "3.4.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/thephpleague/container.git",
-        "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/thephpleague/container/zipball/84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
-        "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.0 || ^8.0",
-        "psr/container": "^1.0.0"
-      },
-      "provide": {
-        "psr/container-implementation": "^1.0"
-      },
-      "replace": {
-        "orno/di": "~2.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^7.0",
-        "roave/security-advisories": "dev-latest",
-        "scrutinizer/ocular": "^1.8",
-        "squizlabs/php_codesniffer": "^3.5"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "3.x-dev",
-          "dev-3.x": "3.x-dev",
-          "dev-2.x": "2.x-dev",
-          "dev-1.x": "1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "League\\Container\\": "src"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Phil Bennett",
-          "email": "philipobenito@gmail.com",
-          "homepage": "http://www.philipobenito.com",
-          "role": "Developer"
-        }
-      ],
-      "description": "A fast and intuitive dependency injection container.",
-      "homepage": "https://github.com/thephpleague/container",
-      "keywords": [
-        "container",
-        "dependency",
-        "di",
-        "injection",
-        "league",
-        "provider",
-        "service"
-      ],
-      "support": {
-        "issues": "https://github.com/thephpleague/container/issues",
-        "source": "https://github.com/thephpleague/container/tree/3.4.1"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/philipobenito",
-          "type": "github"
-        }
-      ],
-      "time": "2021-07-09T08:23:52+00:00"
-    },
-    {
-      "name": "league/event",
-      "version": "2.2.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/thephpleague/event.git",
-        "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/thephpleague/event/zipball/d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
-        "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=5.4.0"
-      },
-      "require-dev": {
-        "henrikbjorn/phpspec-code-coverage": "~1.0.1",
-        "phpspec/phpspec": "^2.2"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.2-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "League\\Event\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Frank de Jonge",
-          "email": "info@frenky.net"
-        }
-      ],
-      "description": "Event package",
-      "keywords": [
-        "emitter",
-        "event",
-        "listener"
-      ],
-      "support": {
-        "issues": "https://github.com/thephpleague/event/issues",
-        "source": "https://github.com/thephpleague/event/tree/master"
-      },
-      "time": "2018-11-26T11:52:41+00:00"
-    },
-    {
-      "name": "league/flysystem",
-      "version": "1.1.9",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/thephpleague/flysystem.git",
-        "reference": "094defdb4a7001845300334e7c1ee2335925ef99"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/094defdb4a7001845300334e7c1ee2335925ef99",
-        "reference": "094defdb4a7001845300334e7c1ee2335925ef99",
-        "shasum": ""
-      },
-      "require": {
-        "ext-fileinfo": "*",
-        "league/mime-type-detection": "^1.3",
-        "php": "^7.2.5 || ^8.0"
-      },
-      "conflict": {
-        "league/flysystem-sftp": "<1.0.6"
-      },
-      "require-dev": {
-        "phpspec/prophecy": "^1.11.1",
-        "phpunit/phpunit": "^8.5.8"
-      },
-      "suggest": {
-        "ext-ftp": "Allows you to use FTP server storage",
-        "ext-openssl": "Allows you to use FTPS server storage",
-        "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
-        "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
-        "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
-        "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
-        "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
-        "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
-        "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
-        "league/flysystem-webdav": "Allows you to use WebDAV storage",
-        "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
-        "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
-        "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.1-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "League\\Flysystem\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Frank de Jonge",
-          "email": "info@frenky.net"
-        }
-      ],
-      "description": "Filesystem abstraction: Many filesystems, one API.",
-      "keywords": [
-        "Cloud Files",
-        "WebDAV",
-        "abstraction",
-        "aws",
-        "cloud",
-        "copy.com",
-        "dropbox",
-        "file systems",
-        "files",
-        "filesystem",
-        "filesystems",
-        "ftp",
-        "rackspace",
-        "remote",
-        "s3",
-        "sftp",
-        "storage"
-      ],
-      "support": {
-        "issues": "https://github.com/thephpleague/flysystem/issues",
-        "source": "https://github.com/thephpleague/flysystem/tree/1.1.9"
-      },
-      "funding": [
-        {
-          "url": "https://offset.earth/frankdejonge",
-          "type": "other"
-        }
-      ],
-      "time": "2021-12-09T09:40:50+00:00"
-    },
-    {
-      "name": "league/flysystem-cached-adapter",
-      "version": "1.1.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/thephpleague/flysystem-cached-adapter.git",
-        "reference": "d1925efb2207ac4be3ad0c40b8277175f99ffaff"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/thephpleague/flysystem-cached-adapter/zipball/d1925efb2207ac4be3ad0c40b8277175f99ffaff",
-        "reference": "d1925efb2207ac4be3ad0c40b8277175f99ffaff",
-        "shasum": ""
-      },
-      "require": {
-        "league/flysystem": "~1.0",
-        "psr/cache": "^1.0.0"
-      },
-      "require-dev": {
-        "mockery/mockery": "~0.9",
-        "phpspec/phpspec": "^3.4",
-        "phpunit/phpunit": "^5.7",
-        "predis/predis": "~1.0",
-        "tedivm/stash": "~0.12"
-      },
-      "suggest": {
-        "ext-phpredis": "Pure C implemented extension for PHP"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "League\\Flysystem\\Cached\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "frankdejonge",
-          "email": "info@frenky.net"
-        }
-      ],
-      "description": "An adapter decorator to enable meta-data caching.",
-      "support": {
-        "issues": "https://github.com/thephpleague/flysystem-cached-adapter/issues",
-        "source": "https://github.com/thephpleague/flysystem-cached-adapter/tree/master"
-      },
-      "time": "2020-07-25T15:56:04+00:00"
-    },
-    {
-      "name": "league/mime-type-detection",
-      "version": "1.9.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/thephpleague/mime-type-detection.git",
-        "reference": "aa70e813a6ad3d1558fc927863d47309b4c23e69"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/aa70e813a6ad3d1558fc927863d47309b4c23e69",
-        "reference": "aa70e813a6ad3d1558fc927863d47309b4c23e69",
-        "shasum": ""
-      },
-      "require": {
-        "ext-fileinfo": "*",
-        "php": "^7.2 || ^8.0"
-      },
-      "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.2",
-        "phpstan/phpstan": "^0.12.68",
-        "phpunit/phpunit": "^8.5.8 || ^9.3"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "League\\MimeTypeDetection\\": "src"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Frank de Jonge",
-          "email": "info@frankdejonge.nl"
-        }
-      ],
-      "description": "Mime-type detection for Flysystem",
-      "support": {
-        "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-        "source": "https://github.com/thephpleague/mime-type-detection/tree/1.9.0"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/frankdejonge",
-          "type": "github"
+            "name": "easyrdf/easyrdf",
+            "version": "0.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/easyrdf/easyrdf.git",
+                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/easyrdf/easyrdf/zipball/acd09dfe0555fbcfa254291e433c45fdd4652566",
+                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-pcre": "*",
+                "php": ">=5.2.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.5",
+                "sami/sami": "~1.4",
+                "squizlabs/php_codesniffer": "~1.4.3"
+            },
+            "suggest": {
+                "ml/json-ld": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "EasyRdf_": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nicholas Humfrey",
+                    "email": "njh@aelius.com",
+                    "homepage": "http://www.aelius.com/njh/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Alexey Zakhlestin",
+                    "email": "indeyets@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
+            "homepage": "http://www.easyrdf.org/",
+            "keywords": [
+                "Linked Data",
+                "RDF",
+                "Semantic Web",
+                "Turtle",
+                "rdfa",
+                "sparql"
+            ],
+            "support": {
+                "forum": "http://groups.google.com/group/easyrdf/",
+                "irc": "irc://chat.freenode.net/easyrdf",
+                "issues": "http://github.com/njh/easyrdf/issues",
+                "source": "https://github.com/easyrdf/easyrdf/tree/0.9.1"
+            },
+            "time": "2015-02-27T09:45:49+00:00"
         },
         {
-          "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2021-11-21T11:48:40+00:00"
-    },
-    {
-      "name": "league/oauth2-server",
-      "version": "8.1.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/thephpleague/oauth2-server.git",
-        "reference": "09f22e8121fa1832962dba18213b80d4267ef8a3"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/09f22e8121fa1832962dba18213b80d4267ef8a3",
-        "reference": "09f22e8121fa1832962dba18213b80d4267ef8a3",
-        "shasum": ""
-      },
-      "require": {
-        "defuse/php-encryption": "^2.2.1",
-        "ext-json": "*",
-        "ext-openssl": "*",
-        "lcobucci/jwt": "^3.3.1",
-        "league/event": "^2.2",
-        "php": ">=7.2.0",
-        "psr/http-message": "^1.0.1"
-      },
-      "replace": {
-        "league/oauth2server": "*",
-        "lncd/oauth2": "*"
-      },
-      "require-dev": {
-        "laminas/laminas-diactoros": "^2.3.0",
-        "phpstan/phpstan": "^0.11.19",
-        "phpstan/phpstan-phpunit": "^0.11.2",
-        "phpunit/phpunit": "^8.5.4 || ^9.1.3",
-        "roave/security-advisories": "dev-master"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "League\\OAuth2\\Server\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Alex Bilbie",
-          "email": "hello@alexbilbie.com",
-          "homepage": "http://www.alexbilbie.com",
-          "role": "Developer"
+            "name": "fgrosse/phpasn1",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/fgrosse/PHPASN1.git",
+                "reference": "eef488991d53e58e60c9554b09b1201ca5ba9296"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/fgrosse/PHPASN1/zipball/eef488991d53e58e60c9554b09b1201ca5ba9296",
+                "reference": "eef488991d53e58e60c9554b09b1201ca5ba9296",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "~2.0",
+                "phpunit/phpunit": "^6.3 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-bcmath": "BCmath is the fallback extension for big integer calculations",
+                "ext-curl": "For loading OID information from the web if they have not bee defined statically",
+                "ext-gmp": "GMP is the preferred extension for big integer calculations",
+                "phpseclib/bcmath_compat": "BCmath polyfill for servers where neither GMP nor BCmath is available"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FG\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Friedrich Große",
+                    "email": "friedrich.grosse@gmail.com",
+                    "homepage": "https://github.com/FGrosse",
+                    "role": "Author"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/FGrosse/PHPASN1/contributors"
+                }
+            ],
+            "description": "A PHP Framework that allows you to encode and decode arbitrary ASN.1 structures using the ITU-T X.690 Encoding Rules.",
+            "homepage": "https://github.com/FGrosse/PHPASN1",
+            "keywords": [
+                "DER",
+                "asn.1",
+                "asn1",
+                "ber",
+                "binary",
+                "decoding",
+                "encoding",
+                "x.509",
+                "x.690",
+                "x509",
+                "x690"
+            ],
+            "support": {
+                "issues": "https://github.com/fgrosse/PHPASN1/issues",
+                "source": "https://github.com/fgrosse/PHPASN1/tree/v2.4.0"
+            },
+            "time": "2021-12-11T12:41:06+00:00"
         },
         {
-          "name": "Andy Millington",
-          "email": "andrew@noexceptions.io",
-          "homepage": "https://www.noexceptions.io",
-          "role": "Developer"
-        }
-      ],
-      "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
-      "homepage": "https://oauth2.thephpleague.com/",
-      "keywords": [
-        "Authentication",
-        "api",
-        "auth",
-        "authorisation",
-        "authorization",
-        "oauth",
-        "oauth 2",
-        "oauth 2.0",
-        "oauth2",
-        "protect",
-        "resource",
-        "secure",
-        "server"
-      ],
-      "support": {
-        "issues": "https://github.com/thephpleague/oauth2-server/issues",
-        "source": "https://github.com/thephpleague/oauth2-server/tree/8.1.1"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sephster",
-          "type": "github"
-        }
-      ],
-      "time": "2020-07-01T11:33:50+00:00"
-    },
-    {
-      "name": "league/route",
-      "version": "4.5.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/thephpleague/route.git",
-        "reference": "bb97a32303fc753a771cf2b41aa789f95dfaf00a"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/thephpleague/route/zipball/bb97a32303fc753a771cf2b41aa789f95dfaf00a",
-        "reference": "bb97a32303fc753a771cf2b41aa789f95dfaf00a",
-        "shasum": ""
-      },
-      "require": {
-        "nikic/fast-route": "^1.0",
-        "php": "^7.1 || ^8.0",
-        "psr/container": "^1.0",
-        "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
-        "psr/http-server-handler": "^1.0",
-        "psr/http-server-middleware": "^1.0"
-      },
-      "replace": {
-        "orno/http": "~1.0",
-        "orno/route": "~1.0"
-      },
-      "require-dev": {
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^7.5",
-        "roave/security-advisories": "dev-master",
-        "scrutinizer/ocular": "^1.8",
-        "squizlabs/php_codesniffer": "^3.5"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.x-dev",
-          "dev-4.x": "4.x-dev",
-          "dev-3.x": "3.x-dev",
-          "dev-2.x": "2.x-dev",
-          "dev-1.x": "1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "League\\Route\\": "src"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Phil Bennett",
-          "email": "philipobenito@gmail.com",
-          "role": "Developer"
-        }
-      ],
-      "description": "Fast routing and dispatch component including PSR-15 middleware, built on top of FastRoute.",
-      "homepage": "https://github.com/thephpleague/route",
-      "keywords": [
-        "dispatcher",
-        "league",
-        "psr-15",
-        "psr-7",
-        "psr15",
-        "psr7",
-        "route",
-        "router"
-      ],
-      "support": {
-        "issues": "https://github.com/thephpleague/route/issues",
-        "source": "https://github.com/thephpleague/route/tree/4.5.1"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/philipobenito",
-          "type": "github"
-        }
-      ],
-      "time": "2021-01-25T14:48:58+00:00"
-    },
-    {
-      "name": "mjrider/flysystem-factory",
-      "version": "v0.5.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/mjrider/flysystem-factory.git",
-        "reference": "feaf9a50e4870b9ef3a6ca89ef907e7401db55ca"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/mjrider/flysystem-factory/zipball/feaf9a50e4870b9ef3a6ca89ef907e7401db55ca",
-        "reference": "feaf9a50e4870b9ef3a6ca89ef907e7401db55ca",
-        "shasum": ""
-      },
-      "require": {
-        "arc/web": "^1.1 || ^2.1",
-        "league/flysystem": "^1.0",
-        "league/flysystem-cached-adapter": "^1.0",
-        "php": "~7.0"
-      },
-      "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
-        "league/flysystem-aws-s3-v3": "1.0.25",
-        "league/flysystem-rackspace": "1.0.5",
-        "mhetreramesh/flysystem-backblaze": "1.1.4",
-        "nimbusoft/flysystem-openstack-swift": "0.3.3",
-        "phpcompatibility/php-compatibility": "9.3.5",
-        "phpunit/phpunit": "~4.0 | ~5.0 | ~6.0",
-        "predis/predis": "1.1.1"
-      },
-      "suggest": {
-        "ext-memcached": "memcached cache support",
-        "ext-phpredis": "phpredis cache support",
-        "league/flysystem-aws-s3-v3": "For S3 support",
-        "mhetreramesh/flysystem-backblaze": "For Backblaze support",
-        "nimbusoft/flysystem-openstack-swift": "For openstack support",
-        "predis/predis": "predis cache support"
-      },
-      "type": "library",
-      "autoload": {
-        "files": [
-          "src/functions.php"
-        ],
-        "psr-4": {
-          "MJRider\\FlysystemFactory\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Robbert Müller",
-          "role": "Developer"
-        }
-      ],
-      "description": "Simple factory library to create a flysystem instance from a url",
-      "homepage": "https://github.com/mjrider/flysystem-factory",
-      "keywords": [
-        "Flysystem",
-        "factory",
-        "files",
-        "filesystem",
-        "filesystems",
-        "storage"
-      ],
-      "support": {
-        "issues": "https://github.com/mjrider/flysystem-factory/issues",
-        "source": "https://github.com/mjrider/flysystem-factory/tree/master"
-      },
-      "time": "2020-08-13T12:45:21+00:00"
-    },
-    {
-      "name": "ml/iri",
-      "version": "1.1.4",
-      "target-dir": "ML/IRI",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/lanthaler/IRI.git",
-        "reference": "cbd44fa913e00ea624241b38cefaa99da8d71341"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/lanthaler/IRI/zipball/cbd44fa913e00ea624241b38cefaa99da8d71341",
-        "reference": "cbd44fa913e00ea624241b38cefaa99da8d71341",
-        "shasum": ""
-      },
-      "require": {
-        "lib-pcre": ">=4.0",
-        "php": ">=5.3.0"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-0": {
-          "ML\\IRI": ""
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Markus Lanthaler",
-          "email": "mail@markus-lanthaler.com",
-          "homepage": "http://www.markus-lanthaler.com",
-          "role": "Developer"
-        }
-      ],
-      "description": "IRI handling for PHP",
-      "homepage": "http://www.markus-lanthaler.com",
-      "keywords": [
-        "URN",
-        "iri",
-        "uri",
-        "url"
-      ],
-      "support": {
-        "issues": "https://github.com/lanthaler/IRI/issues",
-        "source": "https://github.com/lanthaler/IRI/tree/master"
-      },
-      "time": "2014-01-21T13:43:39+00:00"
-    },
-    {
-      "name": "ml/json-ld",
-      "version": "1.2.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/lanthaler/JsonLD.git",
-        "reference": "c74a1aed5979ed1cfb1be35a55a305fd30e30b93"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/lanthaler/JsonLD/zipball/c74a1aed5979ed1cfb1be35a55a305fd30e30b93",
-        "reference": "c74a1aed5979ed1cfb1be35a55a305fd30e30b93",
-        "shasum": ""
-      },
-      "require": {
-        "ext-json": "*",
-        "ml/iri": "^1.1.1",
-        "php": ">=5.3.0"
-      },
-      "require-dev": {
-        "json-ld/tests": "1.0",
-        "phpunit/phpunit": "^4"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "ML\\JsonLD\\": ""
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Markus Lanthaler",
-          "email": "mail@markus-lanthaler.com",
-          "homepage": "http://www.markus-lanthaler.com",
-          "role": "Developer"
-        }
-      ],
-      "description": "JSON-LD Processor for PHP",
-      "homepage": "http://www.markus-lanthaler.com",
-      "keywords": [
-        "JSON-LD",
-        "jsonld"
-      ],
-      "support": {
-        "issues": "https://github.com/lanthaler/JsonLD/issues",
-        "source": "https://github.com/lanthaler/JsonLD/tree/1.2.0"
-      },
-      "time": "2020-06-16T17:45:06+00:00"
-    },
-    {
-      "name": "nikic/fast-route",
-      "version": "v1.3.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/nikic/FastRoute.git",
-        "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
-        "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=5.4.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^4.8.35|~5.7"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "FastRoute\\": "src/"
-        },
-        "files": [
-          "src/functions.php"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Nikita Popov",
-          "email": "nikic@php.net"
-        }
-      ],
-      "description": "Fast request router for PHP",
-      "keywords": [
-        "router",
-        "routing"
-      ],
-      "support": {
-        "issues": "https://github.com/nikic/FastRoute/issues",
-        "source": "https://github.com/nikic/FastRoute/tree/master"
-      },
-      "time": "2018-02-13T20:26:39+00:00"
-    },
-    {
-      "name": "paragonie/constant_time_encoding",
-      "version": "v2.4.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/paragonie/constant_time_encoding.git",
-        "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
-        "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7|^8"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^6|^7|^8|^9",
-        "vimeo/psalm": "^1|^2|^3|^4"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "ParagonIE\\ConstantTime\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Paragon Initiative Enterprises",
-          "email": "security@paragonie.com",
-          "homepage": "https://paragonie.com",
-          "role": "Maintainer"
+            "name": "laminas/laminas-diactoros",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-diactoros.git",
+                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
+                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "conflict": {
+                "phpspec/prophecy": "<1.9.0",
+                "zendframework/zend-diactoros": "*"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "ext-dom": "*",
+                "ext-gd": "*",
+                "ext-libxml": "*",
+                "http-interop/http-factory-tests": "^0.8.0",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "php-http/psr7-integration-tests": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.1",
+                "psalm/plugin-phpunit": "^0.14.0",
+                "vimeo/psalm": "^4.3"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\Diactoros\\ConfigProvider",
+                    "module": "Laminas\\Diactoros"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions/create_uploaded_file.php",
+                    "src/functions/marshal_headers_from_sapi.php",
+                    "src/functions/marshal_method_from_sapi.php",
+                    "src/functions/marshal_protocol_version_from_sapi.php",
+                    "src/functions/marshal_uri_from_sapi.php",
+                    "src/functions/normalize_server.php",
+                    "src/functions/normalize_uploaded_files.php",
+                    "src/functions/parse_cookie_header.php",
+                    "src/functions/create_uploaded_file.legacy.php",
+                    "src/functions/marshal_headers_from_sapi.legacy.php",
+                    "src/functions/marshal_method_from_sapi.legacy.php",
+                    "src/functions/marshal_protocol_version_from_sapi.legacy.php",
+                    "src/functions/marshal_uri_from_sapi.legacy.php",
+                    "src/functions/normalize_server.legacy.php",
+                    "src/functions/normalize_uploaded_files.legacy.php",
+                    "src/functions/parse_cookie_header.legacy.php"
+                ],
+                "psr-4": {
+                    "Laminas\\Diactoros\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "PSR HTTP Message implementations",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "http",
+                "laminas",
+                "psr",
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-diactoros/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-diactoros/issues",
+                "rss": "https://github.com/laminas/laminas-diactoros/releases.atom",
+                "source": "https://github.com/laminas/laminas-diactoros"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-22T03:54:36+00:00"
         },
         {
-          "name": "Steve 'Sc00bz' Thomas",
-          "email": "steve@tobtu.com",
-          "homepage": "https://www.tobtu.com",
-          "role": "Original Developer"
-        }
-      ],
-      "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
-      "keywords": [
-        "base16",
-        "base32",
-        "base32_decode",
-        "base32_encode",
-        "base64",
-        "base64_decode",
-        "base64_encode",
-        "bin2hex",
-        "encoding",
-        "hex",
-        "hex2bin",
-        "rfc4648"
-      ],
-      "support": {
-        "email": "info@paragonie.com",
-        "issues": "https://github.com/paragonie/constant_time_encoding/issues",
-        "source": "https://github.com/paragonie/constant_time_encoding"
-      },
-      "time": "2020-12-06T15:14:20+00:00"
-    },
-    {
-      "name": "paragonie/random_compat",
-      "version": "v9.99.100",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/paragonie/random_compat.git",
-        "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
-        "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">= 7"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "4.*|5.*",
-        "vimeo/psalm": "^1"
-      },
-      "suggest": {
-        "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
-      },
-      "type": "library",
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
+            "name": "laminas/laminas-httphandlerrunner",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-httphandlerrunner.git",
+                "reference": "5f94e55d93f756e8ad07b9049aeb3d6d84582d0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-httphandlerrunner/zipball/5f94e55d93f756e8ad07b9049aeb3d6d84582d0e",
+                "reference": "5f94e55d93f756e8ad07b9049aeb3d6d84582d0e",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "psr/http-message": "^1.0",
+                "psr/http-message-implementation": "^1.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "replace": {
+                "zendframework/zend-httphandlerrunner": "^1.1.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-diactoros": "^2.8.0",
+                "phpunit/phpunit": "^9.5.9",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.10.0"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\HttpHandlerRunner\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\HttpHandlerRunner\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Execute PSR-15 RequestHandlerInterface instances and emit responses they generate.",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "components",
+                "laminas",
+                "mezzio",
+                "psr-15",
+                "psr-7"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-httphandlerrunner/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-httphandlerrunner/issues",
+                "rss": "https://github.com/laminas/laminas-httphandlerrunner/releases.atom",
+                "source": "https://github.com/laminas/laminas-httphandlerrunner"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-22T09:17:54+00:00"
+        },
         {
-          "name": "Paragon Initiative Enterprises",
-          "email": "security@paragonie.com",
-          "homepage": "https://paragonie.com"
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
+                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "support": {
+                "forum": "https://discourse.laminas.dev/",
+                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
+                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
+                "source": "https://github.com/laminas/laminas-zendframework-bridge"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-12-21T14:34:37+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "3.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "c1123697f6a2ec29162b82f170dd4a491f524773"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/c1123697f6a2ec29162b82f170dd4a491f524773",
+                "reference": "c1123697f6a2ec29162b82f170dd4a491f524773",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "~1.5",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/php-invoker": "~1.1",
+                "phpunit/phpunit": "^5.7 || ^7.3",
+                "squizlabs/php_codesniffer": "~2.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Otávio Cobucci Oblonczyk",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/3.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-08-20T13:22:28+00:00"
+        },
+        {
+            "name": "league/container",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/container.git",
+                "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
+                "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/container": "^1.0.0"
+            },
+            "provide": {
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "orno/di": "~2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0 || ^7.0",
+                "roave/security-advisories": "dev-latest",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Container\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "philipobenito@gmail.com",
+                    "homepage": "http://www.philipobenito.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fast and intuitive dependency injection container.",
+            "homepage": "https://github.com/thephpleague/container",
+            "keywords": [
+                "container",
+                "dependency",
+                "di",
+                "injection",
+                "league",
+                "provider",
+                "service"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/3.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-09T08:23:52+00:00"
+        },
+        {
+            "name": "league/event",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/event.git",
+                "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/event/zipball/d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
+                "reference": "d2cc124cf9a3fab2bb4ff963307f60361ce4d119",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "~1.0.1",
+                "phpspec/phpspec": "^2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Event\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Event package",
+            "keywords": [
+                "emitter",
+                "event",
+                "listener"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/event/issues",
+                "source": "https://github.com/thephpleague/event/tree/master"
+            },
+            "time": "2018-11-26T11:52:41+00:00"
+        },
+        {
+            "name": "league/flysystem",
+            "version": "1.1.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "094defdb4a7001845300334e7c1ee2335925ef99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/094defdb4a7001845300334e7c1ee2335925ef99",
+                "reference": "094defdb4a7001845300334e7c1ee2335925ef99",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/mime-type-detection": "^1.3",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
+            "require-dev": {
+                "phpspec/prophecy": "^1.11.1",
+                "phpunit/phpunit": "^8.5.8"
+            },
+            "suggest": {
+                "ext-ftp": "Allows you to use FTP server storage",
+                "ext-openssl": "Allows you to use FTPS server storage",
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "spatie/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "srmklive/flysystem-dropbox-v2": "Allows you to use Dropbox storage for PHP 5 applications"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "Filesystem abstraction: Many filesystems, one API.",
+            "keywords": [
+                "Cloud Files",
+                "WebDAV",
+                "abstraction",
+                "aws",
+                "cloud",
+                "copy.com",
+                "dropbox",
+                "file systems",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "rackspace",
+                "remote",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/1.1.9"
+            },
+            "funding": [
+                {
+                    "url": "https://offset.earth/frankdejonge",
+                    "type": "other"
+                }
+            ],
+            "time": "2021-12-09T09:40:50+00:00"
+        },
+        {
+            "name": "league/flysystem-cached-adapter",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-cached-adapter.git",
+                "reference": "d1925efb2207ac4be3ad0c40b8277175f99ffaff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-cached-adapter/zipball/d1925efb2207ac4be3ad0c40b8277175f99ffaff",
+                "reference": "d1925efb2207ac4be3ad0c40b8277175f99ffaff",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "~1.0",
+                "psr/cache": "^1.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9",
+                "phpspec/phpspec": "^3.4",
+                "phpunit/phpunit": "^5.7",
+                "predis/predis": "~1.0",
+                "tedivm/stash": "~0.12"
+            },
+            "suggest": {
+                "ext-phpredis": "Pure C implemented extension for PHP"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Cached\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "frankdejonge",
+                    "email": "info@frenky.net"
+                }
+            ],
+            "description": "An adapter decorator to enable meta-data caching.",
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem-cached-adapter/issues",
+                "source": "https://github.com/thephpleague/flysystem-cached-adapter/tree/master"
+            },
+            "time": "2020-07-25T15:56:04+00:00"
+        },
+        {
+            "name": "league/mime-type-detection",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "aa70e813a6ad3d1558fc927863d47309b4c23e69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/aa70e813a6ad3d1558fc927863d47309b4c23e69",
+                "reference": "aa70e813a6ad3d1558fc927863d47309b4c23e69",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-21T11:48:40+00:00"
+        },
+        {
+            "name": "league/oauth2-server",
+            "version": "8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/oauth2-server.git",
+                "reference": "09f22e8121fa1832962dba18213b80d4267ef8a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/09f22e8121fa1832962dba18213b80d4267ef8a3",
+                "reference": "09f22e8121fa1832962dba18213b80d4267ef8a3",
+                "shasum": ""
+            },
+            "require": {
+                "defuse/php-encryption": "^2.2.1",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "lcobucci/jwt": "^3.3.1",
+                "league/event": "^2.2",
+                "php": ">=7.2.0",
+                "psr/http-message": "^1.0.1"
+            },
+            "replace": {
+                "league/oauth2server": "*",
+                "lncd/oauth2": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-diactoros": "^2.3.0",
+                "phpstan/phpstan": "^0.11.19",
+                "phpstan/phpstan-phpunit": "^0.11.2",
+                "phpunit/phpunit": "^8.5.4 || ^9.1.3",
+                "roave/security-advisories": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\OAuth2\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Bilbie",
+                    "email": "hello@alexbilbie.com",
+                    "homepage": "http://www.alexbilbie.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andy Millington",
+                    "email": "andrew@noexceptions.io",
+                    "homepage": "https://www.noexceptions.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A lightweight and powerful OAuth 2.0 authorization and resource server library with support for all the core specification grants. This library will allow you to secure your API with OAuth and allow your applications users to approve apps that want to access their data from your API.",
+            "homepage": "https://oauth2.thephpleague.com/",
+            "keywords": [
+                "Authentication",
+                "api",
+                "auth",
+                "authorisation",
+                "authorization",
+                "oauth",
+                "oauth 2",
+                "oauth 2.0",
+                "oauth2",
+                "protect",
+                "resource",
+                "secure",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/oauth2-server/issues",
+                "source": "https://github.com/thephpleague/oauth2-server/tree/8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sephster",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-07-01T11:33:50+00:00"
+        },
+        {
+            "name": "league/route",
+            "version": "4.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/route.git",
+                "reference": "bb97a32303fc753a771cf2b41aa789f95dfaf00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/route/zipball/bb97a32303fc753a771cf2b41aa789f95dfaf00a",
+                "reference": "bb97a32303fc753a771cf2b41aa789f95dfaf00a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/fast-route": "^1.0",
+                "php": "^7.1 || ^8.0",
+                "psr/container": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-handler": "^1.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "replace": {
+                "orno/http": "~1.0",
+                "orno/route": "~1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.5",
+                "roave/security-advisories": "dev-master",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev",
+                    "dev-4.x": "4.x-dev",
+                    "dev-3.x": "3.x-dev",
+                    "dev-2.x": "2.x-dev",
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\Route\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Phil Bennett",
+                    "email": "philipobenito@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Fast routing and dispatch component including PSR-15 middleware, built on top of FastRoute.",
+            "homepage": "https://github.com/thephpleague/route",
+            "keywords": [
+                "dispatcher",
+                "league",
+                "psr-15",
+                "psr-7",
+                "psr15",
+                "psr7",
+                "route",
+                "router"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/route/issues",
+                "source": "https://github.com/thephpleague/route/tree/4.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-25T14:48:58+00:00"
+        },
+        {
+            "name": "mjrider/flysystem-factory",
+            "version": "v0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mjrider/flysystem-factory.git",
+                "reference": "feaf9a50e4870b9ef3a6ca89ef907e7401db55ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mjrider/flysystem-factory/zipball/feaf9a50e4870b9ef3a6ca89ef907e7401db55ca",
+                "reference": "feaf9a50e4870b9ef3a6ca89ef907e7401db55ca",
+                "shasum": ""
+            },
+            "require": {
+                "arc/web": "^1.1 || ^2.1",
+                "league/flysystem": "^1.0",
+                "league/flysystem-cached-adapter": "^1.0",
+                "php": "~7.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
+                "league/flysystem-aws-s3-v3": "1.0.25",
+                "league/flysystem-rackspace": "1.0.5",
+                "mhetreramesh/flysystem-backblaze": "1.1.4",
+                "nimbusoft/flysystem-openstack-swift": "0.3.3",
+                "phpcompatibility/php-compatibility": "9.3.5",
+                "phpunit/phpunit": "~4.0 | ~5.0 | ~6.0",
+                "predis/predis": "1.1.1"
+            },
+            "suggest": {
+                "ext-memcached": "memcached cache support",
+                "ext-phpredis": "phpredis cache support",
+                "league/flysystem-aws-s3-v3": "For S3 support",
+                "mhetreramesh/flysystem-backblaze": "For Backblaze support",
+                "nimbusoft/flysystem-openstack-swift": "For openstack support",
+                "predis/predis": "predis cache support"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "MJRider\\FlysystemFactory\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robbert Müller",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Simple factory library to create a flysystem instance from a url",
+            "homepage": "https://github.com/mjrider/flysystem-factory",
+            "keywords": [
+                "Flysystem",
+                "factory",
+                "files",
+                "filesystem",
+                "filesystems",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/mjrider/flysystem-factory/issues",
+                "source": "https://github.com/mjrider/flysystem-factory/tree/master"
+            },
+            "time": "2020-08-13T12:45:21+00:00"
+        },
+        {
+            "name": "ml/iri",
+            "version": "1.1.4",
+            "target-dir": "ML/IRI",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lanthaler/IRI.git",
+                "reference": "cbd44fa913e00ea624241b38cefaa99da8d71341"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lanthaler/IRI/zipball/cbd44fa913e00ea624241b38cefaa99da8d71341",
+                "reference": "cbd44fa913e00ea624241b38cefaa99da8d71341",
+                "shasum": ""
+            },
+            "require": {
+                "lib-pcre": ">=4.0",
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "ML\\IRI": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Lanthaler",
+                    "email": "mail@markus-lanthaler.com",
+                    "homepage": "http://www.markus-lanthaler.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "IRI handling for PHP",
+            "homepage": "http://www.markus-lanthaler.com",
+            "keywords": [
+                "URN",
+                "iri",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/lanthaler/IRI/issues",
+                "source": "https://github.com/lanthaler/IRI/tree/master"
+            },
+            "time": "2014-01-21T13:43:39+00:00"
+        },
+        {
+            "name": "ml/json-ld",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lanthaler/JsonLD.git",
+                "reference": "c74a1aed5979ed1cfb1be35a55a305fd30e30b93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lanthaler/JsonLD/zipball/c74a1aed5979ed1cfb1be35a55a305fd30e30b93",
+                "reference": "c74a1aed5979ed1cfb1be35a55a305fd30e30b93",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ml/iri": "^1.1.1",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "json-ld/tests": "1.0",
+                "phpunit/phpunit": "^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ML\\JsonLD\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Lanthaler",
+                    "email": "mail@markus-lanthaler.com",
+                    "homepage": "http://www.markus-lanthaler.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "JSON-LD Processor for PHP",
+            "homepage": "http://www.markus-lanthaler.com",
+            "keywords": [
+                "JSON-LD",
+                "jsonld"
+            ],
+            "support": {
+                "issues": "https://github.com/lanthaler/JsonLD/issues",
+                "source": "https://github.com/lanthaler/JsonLD/tree/1.2.0"
+            },
+            "time": "2020-06-16T17:45:06+00:00"
+        },
+        {
+            "name": "nikic/fast-route",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/FastRoute.git",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|~5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FastRoute\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov",
+                    "email": "nikic@php.net"
+                }
+            ],
+            "description": "Fast request router for PHP",
+            "keywords": [
+                "router",
+                "routing"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/FastRoute/issues",
+                "source": "https://github.com/nikic/FastRoute/tree/master"
+            },
+            "time": "2018-02-13T20:26:39+00:00"
+        },
+        {
+            "name": "paragonie/constant_time_encoding",
+            "version": "v2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/constant_time_encoding.git",
+                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/constant_time_encoding/zipball/f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
+                "reference": "f34c2b11eb9d2c9318e13540a1dbc2a3afbd939c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7|^8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6|^7|^8|^9",
+                "vimeo/psalm": "^1|^2|^3|^4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParagonIE\\ConstantTime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Steve 'Sc00bz' Thomas",
+                    "email": "steve@tobtu.com",
+                    "homepage": "https://www.tobtu.com",
+                    "role": "Original Developer"
+                }
+            ],
+            "description": "Constant-time Implementations of RFC 4648 Encoding (Base-64, Base-32, Base-16)",
+            "keywords": [
+                "base16",
+                "base32",
+                "base32_decode",
+                "base32_encode",
+                "base64",
+                "base64_decode",
+                "base64_encode",
+                "bin2hex",
+                "encoding",
+                "hex",
+                "hex2bin",
+                "rfc4648"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/constant_time_encoding/issues",
+                "source": "https://github.com/paragonie/constant_time_encoding"
+            },
+            "time": "2020-12-06T15:14:20+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "support": {
+                "email": "info@paragonie.com",
+                "issues": "https://github.com/paragonie/random_compat/issues",
+                "source": "https://github.com/paragonie/random_compat"
+            },
+            "time": "2020-10-15T08:29:30+00:00"
+        },
+        {
+            "name": "pdsinterop/flysystem-rdf",
+            "version": "v0.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdsinterop/flysystem-rdf.git",
+                "reference": "05cf9c72f023966afd74b81e4d69673617ab38fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdsinterop/flysystem-rdf/zipball/05cf9c72f023966afd74b81e4d69673617ab38fe",
+                "reference": "05cf9c72f023966afd74b81e4d69673617ab38fe",
+                "shasum": ""
+            },
+            "require": {
+                "easyrdf/easyrdf": "^0.9.1",
+                "ext-mbstring": "*",
+                "league/flysystem": "^1.0",
+                "ml/json-ld": "^1.2",
+                "php": "^7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pdsinterop\\Rdf\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Flysystem plugin to transform RDF data between various serialization formats.",
+            "support": {
+                "issues": "https://github.com/pdsinterop/flysystem-rdf/issues",
+                "source": "https://github.com/pdsinterop/flysystem-rdf/tree/v0.4.3"
+            },
+            "time": "2022-01-16T12:30:31+00:00"
+        },
+        {
+            "name": "pdsinterop/solid-auth",
+            "version": "v0.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdsinterop/php-solid-auth.git",
+                "reference": "a22fb36b0189404e48d1443eb87d20693de0fbc3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/a22fb36b0189404e48d1443eb87d20693de0fbc3",
+                "reference": "a22fb36b0189404e48d1443eb87d20693de0fbc3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "laminas/laminas-diactoros": "^2.8",
+                "lcobucci/jwt": "3.3.3",
+                "league/oauth2-server": "^8.1",
+                "php": "^7.3",
+                "web-token/jwt-core": "^2.2"
+            },
+            "require-dev": {
+                "ext-xdebug": "*",
+                "ext-xml": "*",
+                "phpunit/phpunit": "^8.5 | ^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Exceptions.inc.php"
+                ],
+                "psr-4": {
+                    "Pdsinterop\\Solid\\Auth\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
+            "support": {
+                "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
+                "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.6.4"
+            },
+            "time": "2022-01-16T14:33:00+00:00"
+        },
+        {
+            "name": "pdsinterop/solid-crud",
+            "version": "v0.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdsinterop/php-solid-crud.git",
+                "reference": "53103f49da63a9c7a45f19b6846fee832b207b08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdsinterop/php-solid-crud/zipball/53103f49da63a9c7a45f19b6846fee832b207b08",
+                "reference": "53103f49da63a9c7a45f19b6846fee832b207b08",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "laminas/laminas-diactoros": "^2.8",
+                "league/flysystem": "^1.0",
+                "mjrider/flysystem-factory": "^0.5",
+                "pdsinterop/flysystem-rdf": "^0.4",
+                "php": "^7.3",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "textalk/websocket": "^1.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pdsinterop\\Solid\\Resources\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Solid HTTPS REST API specification compliant implementation for handling Resource CRUD",
+            "support": {
+                "issues": "https://github.com/pdsinterop/php-solid-crud/issues",
+                "source": "https://github.com/pdsinterop/php-solid-crud/tree/v0.5.1"
+            },
+            "time": "2022-01-16T13:20:39+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/191a0a1b41ed026b717421931f8d3bd2514ffbf9",
+                "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/promise": "^1.1",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.1",
+                "phpspec/phpspec": "^5.1 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/httplug/issues",
+                "source": "https://github.com/php-http/httplug/tree/master"
+            },
+            "time": "2020-07-13T15:43:23+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
+                "phpspec/phpspec": "^5.1.2 || ^6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/promise/issues",
+                "source": "https://github.com/php-http/promise/tree/1.1.0"
+            },
+            "time": "2020-07-07T09:29:14+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "89bfb45bd8b1abc3b37e910d57f5dbd3174f40fb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/89bfb45bd8b1abc3b37e910d57f5dbd3174f40fb",
+                "reference": "89bfb45bd8b1abc3b37e910d57f5dbd3174f40fb",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phing/phing": "~2.7",
+                "phpunit/phpunit": "^5.7|^6.0|^9.4",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "suggest": {
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-28T23:46:03+00:00"
+        },
+        {
+            "name": "phptal/phptal",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phptal/PHPTAL.git",
+                "reference": "7329e0160cba01f2d7cb7d0ef3c25736d5b08f5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phptal/PHPTAL/zipball/7329e0160cba01f2d7cb7d0ef3c25736d5b08f5c",
+                "reference": "7329e0160cba01f2d7cb7d0ef3c25736d5b08f5c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "bin": [
+                "tools/phptal_lint.php"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "PHPTAL": "classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1+"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bédubourg",
+                    "email": "lbedubourg@motion-twin.com",
+                    "homepage": "http://labe.me"
+                },
+                {
+                    "name": "Kornel Lesiński",
+                    "email": "kornel@geekhood.net",
+                    "homepage": "http://pornel.net/"
+                }
+            ],
+            "description": "PHPTAL is a templating engine for PHP5 that implements Zope Page Templates syntax",
+            "homepage": "http://phptal.org/",
+            "keywords": [
+                "phptal",
+                "template engine",
+                "zope"
+            ],
+            "support": {
+                "issues": "https://github.com/phptal/PHPTAL/issues",
+                "source": "https://github.com/phptal/PHPTAL/tree/1.5.0"
+            },
+            "time": "2021-03-27T17:20:34+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
+            "time": "2016-08-06T20:24:11+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/master"
+            },
+            "time": "2019-04-30T12:38:16+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
+                "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-handler/issues",
+                "source": "https://github.com/php-fig/http-server-handler/tree/master"
+            },
+            "time": "2018-10-30T16:46:14+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/2296f45510945530b9dceb8bcedb5cb84d40c5f5",
+                "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/master"
+            },
+            "time": "2018-10-30T17:12:04+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "spomky-labs/base64url",
+            "version": "v2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Spomky-Labs/base64url.git",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.11|^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.11|^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.11|^0.12",
+                "phpstan/phpstan-phpunit": "^0.11|^0.12",
+                "phpstan/phpstan-strict-rules": "^0.11|^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Base64Url\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky-Labs/base64url/contributors"
+                }
+            ],
+            "description": "Base 64 URL Safe Encoding/Decoding PHP Library",
+            "homepage": "https://github.com/Spomky-Labs/base64url",
+            "keywords": [
+                "base64",
+                "rfc4648",
+                "safe",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/Spomky-Labs/base64url/issues",
+                "source": "https://github.com/Spomky-Labs/base64url/tree/v2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Spomky",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2020-11-03T09:10:25+00:00"
+        },
+        {
+            "name": "textalk/websocket",
+            "version": "1.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Textalk/websocket-php.git",
+                "reference": "846542f82658132cd36acb7a7e8ce0f03960c295"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Textalk/websocket-php/zipball/846542f82658132cd36acb7a7e8ce0f03960c295",
+                "reference": "846542f82658132cd36acb7a7e8ce0f03960c295",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 | ^8.0",
+                "psr/log": "^1 | ^2 | ^3"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^8.0|^9.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WebSocket\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Fredrik Liljegren"
+                },
+                {
+                    "name": "Sören Jensen",
+                    "email": "soren@abicart.se"
+                }
+            ],
+            "description": "WebSocket client and server",
+            "support": {
+                "issues": "https://github.com/Textalk/websocket-php/issues",
+                "source": "https://github.com/Textalk/websocket-php/tree/1.5.5"
+            },
+            "time": "2021-08-07T10:21:40+00:00"
+        },
+        {
+            "name": "web-token/jwt-core",
+            "version": "v2.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/web-token/jwt-core.git",
+                "reference": "53beb6f6c1eec4fa93c1c3e5d9e5701e71fa1678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/web-token/jwt-core/zipball/53beb6f6c1eec4fa93c1c3e5d9e5701e71fa1678",
+                "reference": "53beb6f6c1eec4fa93c1c3e5d9e5701e71fa1678",
+                "shasum": ""
+            },
+            "require": {
+                "brick/math": "^0.8.17|^0.9",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "fgrosse/phpasn1": "^2.0",
+                "php": ">=7.2",
+                "spomky-labs/base64url": "^1.0|^2.0"
+            },
+            "conflict": {
+                "spomky-labs/jose": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jose\\Component\\Core\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florent Morselli",
+                    "homepage": "https://github.com/Spomky"
+                },
+                {
+                    "name": "All contributors",
+                    "homepage": "https://github.com/web-token/jwt-framework/contributors"
+                }
+            ],
+            "description": "Core component of the JWT Framework.",
+            "homepage": "https://github.com/web-token",
+            "keywords": [
+                "JOSE",
+                "JWE",
+                "JWK",
+                "JWKSet",
+                "JWS",
+                "Jot",
+                "RFC7515",
+                "RFC7516",
+                "RFC7517",
+                "RFC7518",
+                "RFC7519",
+                "RFC7520",
+                "bundle",
+                "jwa",
+                "jwt",
+                "symfony"
+            ],
+            "support": {
+                "source": "https://github.com/web-token/jwt-core/tree/v2.2.11"
+            },
+            "funding": [
+                {
+                    "url": "https://www.patreon.com/FlorentMorselli",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-03-17T14:55:52+00:00"
         }
-      ],
-      "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
-      "keywords": [
-        "csprng",
-        "polyfill",
-        "pseudorandom",
-        "random"
-      ],
-      "support": {
-        "email": "info@paragonie.com",
-        "issues": "https://github.com/paragonie/random_compat/issues",
-        "source": "https://github.com/paragonie/random_compat"
-      },
-      "time": "2020-10-15T08:29:30+00:00"
-    },
-    {
-      "name": "pdsinterop/flysystem-rdf",
-      "version": "v0.3.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/pdsinterop/flysystem-rdf.git",
-        "reference": "513f4435a347cebfd2d88ce4bf7e1d03fb2938d7"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/pdsinterop/flysystem-rdf/zipball/513f4435a347cebfd2d88ce4bf7e1d03fb2938d7",
-        "reference": "513f4435a347cebfd2d88ce4bf7e1d03fb2938d7",
-        "shasum": ""
-      },
-      "require": {
-        "easyrdf/easyrdf": "^0.9.1",
-        "ext-mbstring": "*",
-        "league/flysystem": "^1.0",
-        "ml/json-ld": "^1.2",
-        "php": "^7.1"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^7|^8|^9"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Pdsinterop\\Rdf\\": "src/"
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^8.0",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-10T18:47:58+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^7.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-11-13T09:40:50+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.13.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+            },
+            "time": "2021-11-30T19:35:32+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
+            },
+            "time": "2021-02-23T14:00:09+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
+            },
+            "time": "2021-10-19T17:43:47+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
+            },
+            "time": "2022-01-04T19:58:01+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.2",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^6.0 || ^7.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
+            },
+            "time": "2021-12-08T12:19:24+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.13.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-05T09:12:13+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.5.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "2406855036db1102126125537adb1406f7242fdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2406855036db1102126125537adb1406f7242fdd",
+                "reference": "2406855036db1102126125537adb1406f7242fdd",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.3.1",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.7",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^2.3.4",
+                "sebastian/version": "^3.0.2"
+            },
+            "require-dev": {
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
+            },
+            "suggest": {
+                "ext-soap": "*",
+                "ext-xdebug": "*"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ],
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.11"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-25T07:07:57+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:49:45+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:10:38+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
+                "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:52:38+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-11T14:18:36+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-11T13:31:12+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:17:30+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "2.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-15T12:49:02+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-20T20:35:02+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
+            },
+            "time": "2021-03-09T10:59:23+00:00"
         }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "description": "Flysystem plugin to transform RDF data between various serialization formats.",
-      "support": {
-        "issues": "https://github.com/pdsinterop/flysystem-rdf/issues",
-        "source": "https://github.com/pdsinterop/flysystem-rdf/tree/v0.3.0"
-      },
-      "time": "2020-11-09T08:28:14+00:00"
-    },
-    {
-      "name": "pdsinterop/solid-auth",
-      "version": "v0.6.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/pdsinterop/php-solid-auth.git",
-        "reference": "55e1afab5a0eeb0b933cead9f74193072181ea6f"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/pdsinterop/php-solid-auth/zipball/55e1afab5a0eeb0b933cead9f74193072181ea6f",
-        "reference": "55e1afab5a0eeb0b933cead9f74193072181ea6f",
-        "shasum": ""
-      },
-      "require": {
-        "ext-json": "*",
-        "ext-mbstring": "*",
-        "ext-openssl": "*",
-        "laminas/laminas-diactoros": "^2.8",
-        "lcobucci/jwt": "3.3.3",
-        "league/oauth2-server": "^8.1",
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
         "php": "^7.3",
-        "web-token/jwt-core": "^2.2"
-      },
-      "require-dev": {
-        "ext-xdebug": "*",
-        "ext-xml": "*",
-        "phpunit/phpunit": "^8.5 | ^9.5"
-      },
-      "type": "library",
-      "autoload": {
-        "files": [
-          "src/Exceptions.inc.php"
-        ],
-        "psr-4": {
-          "Pdsinterop\\Solid\\Auth\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "description": "OAuth2, OpenID and OIDC for Solid Server implementations.",
-      "support": {
-        "issues": "https://github.com/pdsinterop/php-solid-auth/issues",
-        "source": "https://github.com/pdsinterop/php-solid-auth/tree/v0.6.3"
-      },
-      "time": "2021-12-08T13:43:04+00:00"
-    },
-    {
-      "name": "pdsinterop/solid-crud",
-      "version": "v0.3.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/pdsinterop/php-solid-crud.git",
-        "reference": "a2040d2b5f19fe91dbe0d152d6390c16eb2dcd34"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/pdsinterop/php-solid-crud/zipball/a2040d2b5f19fe91dbe0d152d6390c16eb2dcd34",
-        "reference": "a2040d2b5f19fe91dbe0d152d6390c16eb2dcd34",
-        "shasum": ""
-      },
-      "require": {
-        "ext-mbstring": "*",
-        "laminas/laminas-diactoros": "^2.8",
-        "league/flysystem": "^1.0",
-        "mjrider/flysystem-factory": "^0.5",
-        "pdsinterop/flysystem-rdf": "^0.3",
-        "php": "^7.3",
-        "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0",
-        "textalk/websocket": "^1.5"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Pdsinterop\\Solid\\Resources\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "description": "Solid HTTPS REST API specification compliant implementation for handling Resource CRUD",
-      "support": {
-        "issues": "https://github.com/pdsinterop/php-solid-crud/issues",
-        "source": "https://github.com/pdsinterop/php-solid-crud/tree/v0.3.1"
-      },
-      "time": "2021-12-08T13:37:59+00:00"
-    },
-    {
-      "name": "php-http/httplug",
-      "version": "2.2.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-http/httplug.git",
-        "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-http/httplug/zipball/191a0a1b41ed026b717421931f8d3bd2514ffbf9",
-        "reference": "191a0a1b41ed026b717421931f8d3bd2514ffbf9",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.1 || ^8.0",
-        "php-http/promise": "^1.1",
-        "psr/http-client": "^1.0",
-        "psr/http-message": "^1.0"
-      },
-      "require-dev": {
-        "friends-of-phpspec/phpspec-code-coverage": "^4.1",
-        "phpspec/phpspec": "^5.1 || ^6.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Http\\Client\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Eric GELOEN",
-          "email": "geloen.eric@gmail.com"
-        },
-        {
-          "name": "Márk Sági-Kazár",
-          "email": "mark.sagikazar@gmail.com",
-          "homepage": "https://sagikazarmark.hu"
-        }
-      ],
-      "description": "HTTPlug, the HTTP client abstraction for PHP",
-      "homepage": "http://httplug.io",
-      "keywords": [
-        "client",
-        "http"
-      ],
-      "support": {
-        "issues": "https://github.com/php-http/httplug/issues",
-        "source": "https://github.com/php-http/httplug/tree/master"
-      },
-      "time": "2020-07-13T15:43:23+00:00"
-    },
-    {
-      "name": "php-http/promise",
-      "version": "1.1.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-http/promise.git",
-        "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-http/promise/zipball/4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
-        "reference": "4c4c1f9b7289a2ec57cde7f1e9762a5789506f88",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.1 || ^8.0"
-      },
-      "require-dev": {
-        "friends-of-phpspec/phpspec-code-coverage": "^4.3.2",
-        "phpspec/phpspec": "^5.1.2 || ^6.2"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.1-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Http\\Promise\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Joel Wurtz",
-          "email": "joel.wurtz@gmail.com"
-        },
-        {
-          "name": "Márk Sági-Kazár",
-          "email": "mark.sagikazar@gmail.com"
-        }
-      ],
-      "description": "Promise used for asynchronous HTTP requests",
-      "homepage": "http://httplug.io",
-      "keywords": [
-        "promise"
-      ],
-      "support": {
-        "issues": "https://github.com/php-http/promise/issues",
-        "source": "https://github.com/php-http/promise/tree/1.1.0"
-      },
-      "time": "2020-07-07T09:29:14+00:00"
-    },
-    {
-      "name": "phpseclib/phpseclib",
-      "version": "3.0.12",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phpseclib/phpseclib.git",
-        "reference": "89bfb45bd8b1abc3b37e910d57f5dbd3174f40fb"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/89bfb45bd8b1abc3b37e910d57f5dbd3174f40fb",
-        "reference": "89bfb45bd8b1abc3b37e910d57f5dbd3174f40fb",
-        "shasum": ""
-      },
-      "require": {
-        "paragonie/constant_time_encoding": "^1|^2",
-        "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
-        "php": ">=5.6.1"
-      },
-      "require-dev": {
-        "phing/phing": "~2.7",
-        "phpunit/phpunit": "^5.7|^6.0|^9.4",
-        "squizlabs/php_codesniffer": "~2.0"
-      },
-      "suggest": {
-        "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
-        "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
-        "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
-        "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
-      },
-      "type": "library",
-      "autoload": {
-        "files": [
-          "phpseclib/bootstrap.php"
-        ],
-        "psr-4": {
-          "phpseclib3\\": "phpseclib/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Jim Wigginton",
-          "email": "terrafrost@php.net",
-          "role": "Lead Developer"
-        },
-        {
-          "name": "Patrick Monnerat",
-          "email": "pm@datasphere.ch",
-          "role": "Developer"
-        },
-        {
-          "name": "Andreas Fischer",
-          "email": "bantu@phpbb.com",
-          "role": "Developer"
-        },
-        {
-          "name": "Hans-Jürgen Petrich",
-          "email": "petrich@tronic-media.com",
-          "role": "Developer"
-        },
-        {
-          "name": "Graham Campbell",
-          "email": "graham@alt-three.com",
-          "role": "Developer"
-        }
-      ],
-      "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
-      "homepage": "http://phpseclib.sourceforge.net",
-      "keywords": [
-        "BigInteger",
-        "aes",
-        "asn.1",
-        "asn1",
-        "blowfish",
-        "crypto",
-        "cryptography",
-        "encryption",
-        "rsa",
-        "security",
-        "sftp",
-        "signature",
-        "signing",
-        "ssh",
-        "twofish",
-        "x.509",
-        "x509"
-      ],
-      "support": {
-        "issues": "https://github.com/phpseclib/phpseclib/issues",
-        "source": "https://github.com/phpseclib/phpseclib/tree/3.0.12"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/terrafrost",
-          "type": "github"
-        },
-        {
-          "url": "https://www.patreon.com/phpseclib",
-          "type": "patreon"
-        },
-        {
-          "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2021-11-28T23:46:03+00:00"
-    },
-    {
-      "name": "phptal/phptal",
-      "version": "1.5.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phptal/PHPTAL.git",
-        "reference": "7329e0160cba01f2d7cb7d0ef3c25736d5b08f5c"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phptal/PHPTAL/zipball/7329e0160cba01f2d7cb7d0ef3c25736d5b08f5c",
-        "reference": "7329e0160cba01f2d7cb7d0ef3c25736d5b08f5c",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.3 || ^8.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.5.4"
-      },
-      "bin": [
-        "tools/phptal_lint.php"
-      ],
-      "type": "library",
-      "autoload": {
-        "psr-0": {
-          "PHPTAL": "classes/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "LGPL-2.1+"
-      ],
-      "authors": [
-        {
-          "name": "Laurent Bédubourg",
-          "email": "lbedubourg@motion-twin.com",
-          "homepage": "http://labe.me"
-        },
-        {
-          "name": "Kornel Lesiński",
-          "email": "kornel@geekhood.net",
-          "homepage": "http://pornel.net/"
-        }
-      ],
-      "description": "PHPTAL is a templating engine for PHP5 that implements Zope Page Templates syntax",
-      "homepage": "http://phptal.org/",
-      "keywords": [
-        "phptal",
-        "template engine",
-        "zope"
-      ],
-      "support": {
-        "issues": "https://github.com/phptal/PHPTAL/issues",
-        "source": "https://github.com/phptal/PHPTAL/tree/1.5.0"
-      },
-      "time": "2021-03-27T17:20:34+00:00"
-    },
-    {
-      "name": "psr/cache",
-      "version": "1.0.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/cache.git",
-        "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
-        "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=5.3.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Psr\\Cache\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "http://www.php-fig.org/"
-        }
-      ],
-      "description": "Common interface for caching libraries",
-      "keywords": [
-        "cache",
-        "psr",
-        "psr-6"
-      ],
-      "support": {
-        "source": "https://github.com/php-fig/cache/tree/master"
-      },
-      "time": "2016-08-06T20:24:11+00:00"
-    },
-    {
-      "name": "psr/container",
-      "version": "1.1.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/container.git",
-        "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-        "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.2.0"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Psr\\Container\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "https://www.php-fig.org/"
-        }
-      ],
-      "description": "Common Container Interface (PHP FIG PSR-11)",
-      "homepage": "https://github.com/php-fig/container",
-      "keywords": [
-        "PSR-11",
-        "container",
-        "container-interface",
-        "container-interop",
-        "psr"
-      ],
-      "support": {
-        "issues": "https://github.com/php-fig/container/issues",
-        "source": "https://github.com/php-fig/container/tree/1.1.1"
-      },
-      "time": "2021-03-05T17:36:06+00:00"
-    },
-    {
-      "name": "psr/http-client",
-      "version": "1.0.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/http-client.git",
-        "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-        "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.0 || ^8.0",
-        "psr/http-message": "^1.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Psr\\Http\\Client\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "http://www.php-fig.org/"
-        }
-      ],
-      "description": "Common interface for HTTP clients",
-      "homepage": "https://github.com/php-fig/http-client",
-      "keywords": [
-        "http",
-        "http-client",
-        "psr",
-        "psr-18"
-      ],
-      "support": {
-        "source": "https://github.com/php-fig/http-client/tree/master"
-      },
-      "time": "2020-06-29T06:28:15+00:00"
-    },
-    {
-      "name": "psr/http-factory",
-      "version": "1.0.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/http-factory.git",
-        "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-        "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.0.0",
-        "psr/http-message": "^1.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Psr\\Http\\Message\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "http://www.php-fig.org/"
-        }
-      ],
-      "description": "Common interfaces for PSR-7 HTTP message factories",
-      "keywords": [
-        "factory",
-        "http",
-        "message",
-        "psr",
-        "psr-17",
-        "psr-7",
-        "request",
-        "response"
-      ],
-      "support": {
-        "source": "https://github.com/php-fig/http-factory/tree/master"
-      },
-      "time": "2019-04-30T12:38:16+00:00"
-    },
-    {
-      "name": "psr/http-message",
-      "version": "1.0.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/http-message.git",
-        "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-        "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=5.3.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Psr\\Http\\Message\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "http://www.php-fig.org/"
-        }
-      ],
-      "description": "Common interface for HTTP messages",
-      "homepage": "https://github.com/php-fig/http-message",
-      "keywords": [
-        "http",
-        "http-message",
-        "psr",
-        "psr-7",
-        "request",
-        "response"
-      ],
-      "support": {
-        "source": "https://github.com/php-fig/http-message/tree/master"
-      },
-      "time": "2016-08-06T14:39:51+00:00"
-    },
-    {
-      "name": "psr/http-server-handler",
-      "version": "1.0.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/http-server-handler.git",
-        "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
-        "reference": "aff2f80e33b7f026ec96bb42f63242dc50ffcae7",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.0",
-        "psr/http-message": "^1.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Psr\\Http\\Server\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "http://www.php-fig.org/"
-        }
-      ],
-      "description": "Common interface for HTTP server-side request handler",
-      "keywords": [
-        "handler",
-        "http",
-        "http-interop",
-        "psr",
-        "psr-15",
-        "psr-7",
-        "request",
-        "response",
-        "server"
-      ],
-      "support": {
-        "issues": "https://github.com/php-fig/http-server-handler/issues",
-        "source": "https://github.com/php-fig/http-server-handler/tree/master"
-      },
-      "time": "2018-10-30T16:46:14+00:00"
-    },
-    {
-      "name": "psr/http-server-middleware",
-      "version": "1.0.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/http-server-middleware.git",
-        "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/2296f45510945530b9dceb8bcedb5cb84d40c5f5",
-        "reference": "2296f45510945530b9dceb8bcedb5cb84d40c5f5",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.0",
-        "psr/http-message": "^1.0",
-        "psr/http-server-handler": "^1.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Psr\\Http\\Server\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "http://www.php-fig.org/"
-        }
-      ],
-      "description": "Common interface for HTTP server-side middleware",
-      "keywords": [
-        "http",
-        "http-interop",
-        "middleware",
-        "psr",
-        "psr-15",
-        "psr-7",
-        "request",
-        "response"
-      ],
-      "support": {
-        "issues": "https://github.com/php-fig/http-server-middleware/issues",
-        "source": "https://github.com/php-fig/http-server-middleware/tree/master"
-      },
-      "time": "2018-10-30T17:12:04+00:00"
-    },
-    {
-      "name": "psr/log",
-      "version": "1.1.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/php-fig/log.git",
-        "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-        "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=5.3.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Psr\\Log\\": "Psr/Log/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "PHP-FIG",
-          "homepage": "https://www.php-fig.org/"
-        }
-      ],
-      "description": "Common interface for logging libraries",
-      "homepage": "https://github.com/php-fig/log",
-      "keywords": [
-        "log",
-        "psr",
-        "psr-3"
-      ],
-      "support": {
-        "source": "https://github.com/php-fig/log/tree/1.1.4"
-      },
-      "time": "2021-05-03T11:20:27+00:00"
-    },
-    {
-      "name": "spomky-labs/base64url",
-      "version": "v2.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/Spomky-Labs/base64url.git",
-        "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/Spomky-Labs/base64url/zipball/7752ce931ec285da4ed1f4c5aa27e45e097be61d",
-        "reference": "7752ce931ec285da4ed1f4c5aa27e45e097be61d",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.1"
-      },
-      "require-dev": {
-        "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "^0.11|^0.12",
-        "phpstan/phpstan-beberlei-assert": "^0.11|^0.12",
-        "phpstan/phpstan-deprecation-rules": "^0.11|^0.12",
-        "phpstan/phpstan-phpunit": "^0.11|^0.12",
-        "phpstan/phpstan-strict-rules": "^0.11|^0.12"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Base64Url\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Florent Morselli",
-          "homepage": "https://github.com/Spomky-Labs/base64url/contributors"
-        }
-      ],
-      "description": "Base 64 URL Safe Encoding/Decoding PHP Library",
-      "homepage": "https://github.com/Spomky-Labs/base64url",
-      "keywords": [
-        "base64",
-        "rfc4648",
-        "safe",
-        "url"
-      ],
-      "support": {
-        "issues": "https://github.com/Spomky-Labs/base64url/issues",
-        "source": "https://github.com/Spomky-Labs/base64url/tree/v2.0.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/Spomky",
-          "type": "github"
-        },
-        {
-          "url": "https://www.patreon.com/FlorentMorselli",
-          "type": "patreon"
-        }
-      ],
-      "time": "2020-11-03T09:10:25+00:00"
-    },
-    {
-      "name": "textalk/websocket",
-      "version": "1.5.5",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/Textalk/websocket-php.git",
-        "reference": "846542f82658132cd36acb7a7e8ce0f03960c295"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/Textalk/websocket-php/zipball/846542f82658132cd36acb7a7e8ce0f03960c295",
-        "reference": "846542f82658132cd36acb7a7e8ce0f03960c295",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.2 | ^8.0",
-        "psr/log": "^1 | ^2 | ^3"
-      },
-      "require-dev": {
-        "php-coveralls/php-coveralls": "^2.0",
-        "phpunit/phpunit": "^8.0|^9.0",
-        "squizlabs/php_codesniffer": "^3.5"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "WebSocket\\": "lib"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "ISC"
-      ],
-      "authors": [
-        {
-          "name": "Fredrik Liljegren"
-        },
-        {
-          "name": "Sören Jensen",
-          "email": "soren@abicart.se"
-        }
-      ],
-      "description": "WebSocket client and server",
-      "support": {
-        "issues": "https://github.com/Textalk/websocket-php/issues",
-        "source": "https://github.com/Textalk/websocket-php/tree/1.5.5"
-      },
-      "time": "2021-08-07T10:21:40+00:00"
-    },
-    {
-      "name": "web-token/jwt-core",
-      "version": "v2.2.11",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/web-token/jwt-core.git",
-        "reference": "53beb6f6c1eec4fa93c1c3e5d9e5701e71fa1678"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/web-token/jwt-core/zipball/53beb6f6c1eec4fa93c1c3e5d9e5701e71fa1678",
-        "reference": "53beb6f6c1eec4fa93c1c3e5d9e5701e71fa1678",
-        "shasum": ""
-      },
-      "require": {
-        "brick/math": "^0.8.17|^0.9",
-        "ext-json": "*",
-        "ext-mbstring": "*",
-        "fgrosse/phpasn1": "^2.0",
-        "php": ">=7.2",
-        "spomky-labs/base64url": "^1.0|^2.0"
-      },
-      "conflict": {
-        "spomky-labs/jose": "*"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Jose\\Component\\Core\\": ""
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Florent Morselli",
-          "homepage": "https://github.com/Spomky"
-        },
-        {
-          "name": "All contributors",
-          "homepage": "https://github.com/web-token/jwt-framework/contributors"
-        }
-      ],
-      "description": "Core component of the JWT Framework.",
-      "homepage": "https://github.com/web-token",
-      "keywords": [
-        "JOSE",
-        "JWE",
-        "JWK",
-        "JWKSet",
-        "JWS",
-        "Jot",
-        "RFC7515",
-        "RFC7516",
-        "RFC7517",
-        "RFC7518",
-        "RFC7519",
-        "RFC7520",
-        "bundle",
-        "jwa",
-        "jwt",
-        "symfony"
-      ],
-      "support": {
-        "source": "https://github.com/web-token/jwt-core/tree/v2.2.11"
-      },
-      "funding": [
-        {
-          "url": "https://www.patreon.com/FlorentMorselli",
-          "type": "patreon"
-        }
-      ],
-      "time": "2021-03-17T14:55:52+00:00"
-    }
-  ],
-  "packages-dev": [
-    {
-      "name": "doctrine/instantiator",
-      "version": "1.4.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/doctrine/instantiator.git",
-        "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-        "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.1 || ^8.0"
-      },
-      "require-dev": {
-        "doctrine/coding-standard": "^8.0",
-        "ext-pdo": "*",
-        "ext-phar": "*",
-        "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
-        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Marco Pivetta",
-          "email": "ocramius@gmail.com",
-          "homepage": "https://ocramius.github.io/"
-        }
-      ],
-      "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-      "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-      "keywords": [
-        "constructor",
-        "instantiate"
-      ],
-      "support": {
-        "issues": "https://github.com/doctrine/instantiator/issues",
-        "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
-      },
-      "funding": [
-        {
-          "url": "https://www.doctrine-project.org/sponsorship.html",
-          "type": "custom"
-        },
-        {
-          "url": "https://www.patreon.com/phpdoctrine",
-          "type": "patreon"
-        },
-        {
-          "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2020-11-10T18:47:58+00:00"
-    },
-    {
-      "name": "myclabs/deep-copy",
-      "version": "1.10.2",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/myclabs/DeepCopy.git",
-        "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-        "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.1 || ^8.0"
-      },
-      "replace": {
-        "myclabs/deep-copy": "self.version"
-      },
-      "require-dev": {
-        "doctrine/collections": "^1.0",
-        "doctrine/common": "^2.6",
-        "phpunit/phpunit": "^7.1"
-      },
-      "type": "library",
-      "autoload": {
-        "psr-4": {
-          "DeepCopy\\": "src/DeepCopy/"
-        },
-        "files": [
-          "src/DeepCopy/deep_copy.php"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "description": "Create deep copies (clones) of your objects",
-      "keywords": [
-        "clone",
-        "copy",
-        "duplicate",
-        "object",
-        "object graph"
-      ],
-      "support": {
-        "issues": "https://github.com/myclabs/DeepCopy/issues",
-        "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
-      },
-      "funding": [
-        {
-          "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2020-11-13T09:40:50+00:00"
-    },
-    {
-      "name": "nikic/php-parser",
-      "version": "v4.13.2",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/nikic/PHP-Parser.git",
-        "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
-        "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
-        "shasum": ""
-      },
-      "require": {
-        "ext-tokenizer": "*",
-        "php": ">=7.0"
-      },
-      "require-dev": {
-        "ircmaxell/php-yacc": "^0.0.7",
-        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
-      },
-      "bin": [
-        "bin/php-parse"
-      ],
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.9-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "PhpParser\\": "lib/PhpParser"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Nikita Popov"
-        }
-      ],
-      "description": "A PHP parser written in PHP",
-      "keywords": [
-        "parser",
-        "php"
-      ],
-      "support": {
-        "issues": "https://github.com/nikic/PHP-Parser/issues",
-        "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
-      },
-      "time": "2021-11-30T19:35:32+00:00"
-    },
-    {
-      "name": "phar-io/manifest",
-      "version": "2.0.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phar-io/manifest.git",
-        "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-        "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
-        "shasum": ""
-      },
-      "require": {
-        "ext-dom": "*",
-        "ext-phar": "*",
-        "ext-xmlwriter": "*",
-        "phar-io/version": "^3.0.1",
-        "php": "^7.2 || ^8.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.0.x-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Arne Blankerts",
-          "email": "arne@blankerts.de",
-          "role": "Developer"
-        },
-        {
-          "name": "Sebastian Heuer",
-          "email": "sebastian@phpeople.de",
-          "role": "Developer"
-        },
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "Developer"
-        }
-      ],
-      "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-      "support": {
-        "issues": "https://github.com/phar-io/manifest/issues",
-        "source": "https://github.com/phar-io/manifest/tree/2.0.3"
-      },
-      "time": "2021-07-20T11:28:43+00:00"
-    },
-    {
-      "name": "phar-io/version",
-      "version": "3.1.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phar-io/version.git",
-        "reference": "bae7c545bef187884426f042434e561ab1ddb182"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
-        "reference": "bae7c545bef187884426f042434e561ab1ddb182",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.2 || ^8.0"
-      },
-      "type": "library",
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Arne Blankerts",
-          "email": "arne@blankerts.de",
-          "role": "Developer"
-        },
-        {
-          "name": "Sebastian Heuer",
-          "email": "sebastian@phpeople.de",
-          "role": "Developer"
-        },
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "Developer"
-        }
-      ],
-      "description": "Library for handling version information and constraints",
-      "support": {
-        "issues": "https://github.com/phar-io/version/issues",
-        "source": "https://github.com/phar-io/version/tree/3.1.0"
-      },
-      "time": "2021-02-23T14:00:09+00:00"
-    },
-    {
-      "name": "phpdocumentor/reflection-common",
-      "version": "2.2.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-        "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-        "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.2 || ^8.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-2.x": "2.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "phpDocumentor\\Reflection\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Jaap van Otterdijk",
-          "email": "opensource@ijaap.nl"
-        }
-      ],
-      "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-      "homepage": "http://www.phpdoc.org",
-      "keywords": [
-        "FQSEN",
-        "phpDocumentor",
-        "phpdoc",
-        "reflection",
-        "static analysis"
-      ],
-      "support": {
-        "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
-        "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
-      },
-      "time": "2020-06-27T09:03:43+00:00"
-    },
-    {
-      "name": "phpdocumentor/reflection-docblock",
-      "version": "5.3.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-        "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
-        "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
-        "shasum": ""
-      },
-      "require": {
-        "ext-filter": "*",
-        "php": "^7.2 || ^8.0",
-        "phpdocumentor/reflection-common": "^2.2",
-        "phpdocumentor/type-resolver": "^1.3",
-        "webmozart/assert": "^1.9.1"
-      },
-      "require-dev": {
-        "mockery/mockery": "~1.3.2",
-        "psalm/phar": "^4.8"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "5.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "phpDocumentor\\Reflection\\": "src"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Mike van Riel",
-          "email": "me@mikevanriel.com"
-        },
-        {
-          "name": "Jaap van Otterdijk",
-          "email": "account@ijaap.nl"
-        }
-      ],
-      "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-      "support": {
-        "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-        "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
-      },
-      "time": "2021-10-19T17:43:47+00:00"
-    },
-    {
-      "name": "phpdocumentor/type-resolver",
-      "version": "1.5.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phpDocumentor/TypeResolver.git",
-        "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-        "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.2 || ^8.0",
-        "phpdocumentor/reflection-common": "^2.0"
-      },
-      "require-dev": {
-        "ext-tokenizer": "*",
-        "psalm/phar": "^4.8"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-1.x": "1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "phpDocumentor\\Reflection\\": "src"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Mike van Riel",
-          "email": "me@mikevanriel.com"
-        }
-      ],
-      "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
-      "support": {
-        "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-        "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
-      },
-      "time": "2021-10-02T14:08:47+00:00"
-    },
-    {
-      "name": "phpspec/prophecy",
-      "version": "v1.15.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/phpspec/prophecy.git",
-        "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-        "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
-        "shasum": ""
-      },
-      "require": {
-        "doctrine/instantiator": "^1.2",
-        "php": "^7.2 || ~8.0, <8.2",
-        "phpdocumentor/reflection-docblock": "^5.2",
-        "sebastian/comparator": "^3.0 || ^4.0",
-        "sebastian/recursion-context": "^3.0 || ^4.0"
-      },
-      "require-dev": {
-        "phpspec/phpspec": "^6.0 || ^7.0",
-        "phpunit/phpunit": "^8.0 || ^9.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Prophecy\\": "src/Prophecy"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Konstantin Kudryashov",
-          "email": "ever.zet@gmail.com",
-          "homepage": "http://everzet.com"
-        },
-        {
-          "name": "Marcello Duarte",
-          "email": "marcello.duarte@gmail.com"
-        }
-      ],
-      "description": "Highly opinionated mocking framework for PHP 5.3+",
-      "homepage": "https://github.com/phpspec/prophecy",
-      "keywords": [
-        "Double",
-        "Dummy",
-        "fake",
-        "mock",
-        "spy",
-        "stub"
-      ],
-      "support": {
-        "issues": "https://github.com/phpspec/prophecy/issues",
-        "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
-      },
-      "time": "2021-12-08T12:19:24+00:00"
-    },
-    {
-      "name": "phpunit/php-code-coverage",
-      "version": "9.2.10",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-        "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/d5850aaf931743067f4bfc1ae4cbd06468400687",
-        "reference": "d5850aaf931743067f4bfc1ae4cbd06468400687",
-        "shasum": ""
-      },
-      "require": {
-        "ext-dom": "*",
-        "ext-libxml": "*",
-        "ext-xmlwriter": "*",
-        "nikic/php-parser": "^4.13.0",
-        "php": ">=7.3",
-        "phpunit/php-file-iterator": "^3.0.3",
-        "phpunit/php-text-template": "^2.0.2",
-        "sebastian/code-unit-reverse-lookup": "^2.0.2",
-        "sebastian/complexity": "^2.0",
-        "sebastian/environment": "^5.1.2",
-        "sebastian/lines-of-code": "^1.0.3",
-        "sebastian/version": "^3.0.1",
-        "theseer/tokenizer": "^1.2.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "suggest": {
-        "ext-pcov": "*",
-        "ext-xdebug": "*"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "9.2-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-      "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-      "keywords": [
-        "coverage",
-        "testing",
-        "xunit"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-        "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.10"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2021-12-05T09:12:13+00:00"
-    },
-    {
-      "name": "phpunit/php-file-iterator",
-      "version": "3.0.6",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-        "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-        "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "3.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-      "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-      "keywords": [
-        "filesystem",
-        "iterator"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-        "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2021-12-02T12:48:52+00:00"
-    },
-    {
-      "name": "phpunit/php-invoker",
-      "version": "3.1.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/php-invoker.git",
-        "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-        "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "ext-pcntl": "*",
-        "phpunit/phpunit": "^9.3"
-      },
-      "suggest": {
-        "ext-pcntl": "*"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "3.1-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Invoke callables with a timeout",
-      "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-      "keywords": [
-        "process"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-        "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-09-28T05:58:55+00:00"
-    },
-    {
-      "name": "phpunit/php-text-template",
-      "version": "2.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/php-text-template.git",
-        "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-        "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Simple template engine.",
-      "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-      "keywords": [
-        "template"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-        "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T05:33:50+00:00"
-    },
-    {
-      "name": "phpunit/php-timer",
-      "version": "5.0.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/php-timer.git",
-        "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-        "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "5.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Utility class for timing",
-      "homepage": "https://github.com/sebastianbergmann/php-timer/",
-      "keywords": [
-        "timer"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-        "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T13:16:10+00:00"
-    },
-    {
-      "name": "phpunit/phpunit",
-      "version": "9.5.10",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/phpunit.git",
-        "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
-        "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
-        "shasum": ""
-      },
-      "require": {
-        "doctrine/instantiator": "^1.3.1",
         "ext-dom": "*",
         "ext-json": "*",
-        "ext-libxml": "*",
         "ext-mbstring": "*",
-        "ext-xml": "*",
-        "ext-xmlwriter": "*",
-        "myclabs/deep-copy": "^1.10.1",
-        "phar-io/manifest": "^2.0.3",
-        "phar-io/version": "^3.0.2",
-        "php": ">=7.3",
-        "phpspec/prophecy": "^1.12.1",
-        "phpunit/php-code-coverage": "^9.2.7",
-        "phpunit/php-file-iterator": "^3.0.5",
-        "phpunit/php-invoker": "^3.1.1",
-        "phpunit/php-text-template": "^2.0.3",
-        "phpunit/php-timer": "^5.0.2",
-        "sebastian/cli-parser": "^1.0.1",
-        "sebastian/code-unit": "^1.0.6",
-        "sebastian/comparator": "^4.0.5",
-        "sebastian/diff": "^4.0.3",
-        "sebastian/environment": "^5.1.3",
-        "sebastian/exporter": "^4.0.3",
-        "sebastian/global-state": "^5.0.1",
-        "sebastian/object-enumerator": "^4.0.3",
-        "sebastian/resource-operations": "^3.0.3",
-        "sebastian/type": "^2.3.4",
-        "sebastian/version": "^3.0.2"
-      },
-      "require-dev": {
-        "ext-pdo": "*",
-        "phpspec/prophecy-phpunit": "^2.0.1"
-      },
-      "suggest": {
-        "ext-soap": "*",
-        "ext-xdebug": "*"
-      },
-      "bin": [
-        "phpunit"
-      ],
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "9.5-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ],
-        "files": [
-          "src/Framework/Assert/Functions.php"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "The PHP Unit Testing framework.",
-      "homepage": "https://phpunit.de/",
-      "keywords": [
-        "phpunit",
-        "testing",
-        "xunit"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-        "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
-      },
-      "funding": [
-        {
-          "url": "https://phpunit.de/donate.html",
-          "type": "custom"
-        },
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2021-09-25T07:38:51+00:00"
+        "ext-openssl": "*"
     },
-    {
-      "name": "sebastian/cli-parser",
-      "version": "1.0.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/cli-parser.git",
-        "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-        "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Library for parsing CLI options",
-      "homepage": "https://github.com/sebastianbergmann/cli-parser",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-        "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-09-28T06:08:49+00:00"
-    },
-    {
-      "name": "sebastian/code-unit",
-      "version": "1.0.8",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/code-unit.git",
-        "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-        "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Collection of value objects that represent the PHP code units",
-      "homepage": "https://github.com/sebastianbergmann/code-unit",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-        "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T13:08:54+00:00"
-    },
-    {
-      "name": "sebastian/code-unit-reverse-lookup",
-      "version": "2.0.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-        "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-        "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        }
-      ],
-      "description": "Looks up which function or method a line of code belongs to",
-      "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-        "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-09-28T05:30:19+00:00"
-    },
-    {
-      "name": "sebastian/comparator",
-      "version": "4.0.6",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/comparator.git",
-        "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
-        "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3",
-        "sebastian/diff": "^4.0",
-        "sebastian/exporter": "^4.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        },
-        {
-          "name": "Jeff Welch",
-          "email": "whatthejeff@gmail.com"
-        },
-        {
-          "name": "Volker Dusch",
-          "email": "github@wallbash.com"
-        },
-        {
-          "name": "Bernhard Schussek",
-          "email": "bschussek@2bepublished.at"
-        }
-      ],
-      "description": "Provides the functionality to compare PHP values for equality",
-      "homepage": "https://github.com/sebastianbergmann/comparator",
-      "keywords": [
-        "comparator",
-        "compare",
-        "equality"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/comparator/issues",
-        "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T15:49:45+00:00"
-    },
-    {
-      "name": "sebastian/complexity",
-      "version": "2.0.2",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/complexity.git",
-        "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-        "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
-        "shasum": ""
-      },
-      "require": {
-        "nikic/php-parser": "^4.7",
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Library for calculating the complexity of PHP code units",
-      "homepage": "https://github.com/sebastianbergmann/complexity",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/complexity/issues",
-        "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T15:52:27+00:00"
-    },
-    {
-      "name": "sebastian/diff",
-      "version": "4.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/diff.git",
-        "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-        "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3",
-        "symfony/process": "^4.2 || ^5"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        },
-        {
-          "name": "Kore Nordmann",
-          "email": "mail@kore-nordmann.de"
-        }
-      ],
-      "description": "Diff implementation",
-      "homepage": "https://github.com/sebastianbergmann/diff",
-      "keywords": [
-        "diff",
-        "udiff",
-        "unidiff",
-        "unified diff"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/diff/issues",
-        "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T13:10:38+00:00"
-    },
-    {
-      "name": "sebastian/environment",
-      "version": "5.1.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/environment.git",
-        "reference": "388b6ced16caa751030f6a69e588299fa09200ac"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/388b6ced16caa751030f6a69e588299fa09200ac",
-        "reference": "388b6ced16caa751030f6a69e588299fa09200ac",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "suggest": {
-        "ext-posix": "*"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "5.1-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        }
-      ],
-      "description": "Provides functionality to handle HHVM/PHP environments",
-      "homepage": "http://www.github.com/sebastianbergmann/environment",
-      "keywords": [
-        "Xdebug",
-        "environment",
-        "hhvm"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/environment/issues",
-        "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-09-28T05:52:38+00:00"
-    },
-    {
-      "name": "sebastian/exporter",
-      "version": "4.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/exporter.git",
-        "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
-        "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3",
-        "sebastian/recursion-context": "^4.0"
-      },
-      "require-dev": {
-        "ext-mbstring": "*",
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        },
-        {
-          "name": "Jeff Welch",
-          "email": "whatthejeff@gmail.com"
-        },
-        {
-          "name": "Volker Dusch",
-          "email": "github@wallbash.com"
-        },
-        {
-          "name": "Adam Harvey",
-          "email": "aharvey@php.net"
-        },
-        {
-          "name": "Bernhard Schussek",
-          "email": "bschussek@gmail.com"
-        }
-      ],
-      "description": "Provides the functionality to export PHP variables for visualization",
-      "homepage": "https://www.github.com/sebastianbergmann/exporter",
-      "keywords": [
-        "export",
-        "exporter"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/exporter/issues",
-        "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2021-11-11T14:18:36+00:00"
-    },
-    {
-      "name": "sebastian/global-state",
-      "version": "5.0.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/global-state.git",
-        "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-        "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3",
-        "sebastian/object-reflector": "^2.0",
-        "sebastian/recursion-context": "^4.0"
-      },
-      "require-dev": {
-        "ext-dom": "*",
-        "phpunit/phpunit": "^9.3"
-      },
-      "suggest": {
-        "ext-uopz": "*"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "5.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        }
-      ],
-      "description": "Snapshotting of global state",
-      "homepage": "http://www.github.com/sebastianbergmann/global-state",
-      "keywords": [
-        "global state"
-      ],
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/global-state/issues",
-        "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2021-06-11T13:31:12+00:00"
-    },
-    {
-      "name": "sebastian/lines-of-code",
-      "version": "1.0.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-        "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-        "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-        "shasum": ""
-      },
-      "require": {
-        "nikic/php-parser": "^4.6",
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Library for counting the lines of code in PHP source code",
-      "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-        "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-11-28T06:42:11+00:00"
-    },
-    {
-      "name": "sebastian/object-enumerator",
-      "version": "4.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-        "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-        "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3",
-        "sebastian/object-reflector": "^2.0",
-        "sebastian/recursion-context": "^4.0"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        }
-      ],
-      "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-      "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-        "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T13:12:34+00:00"
-    },
-    {
-      "name": "sebastian/object-reflector",
-      "version": "2.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/object-reflector.git",
-        "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-        "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        }
-      ],
-      "description": "Allows reflection of object attributes, including inherited and non-public ones",
-      "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-        "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T13:14:26+00:00"
-    },
-    {
-      "name": "sebastian/recursion-context",
-      "version": "4.0.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/recursion-context.git",
-        "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-        "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "4.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        },
-        {
-          "name": "Jeff Welch",
-          "email": "whatthejeff@gmail.com"
-        },
-        {
-          "name": "Adam Harvey",
-          "email": "aharvey@php.net"
-        }
-      ],
-      "description": "Provides functionality to recursively process PHP variables",
-      "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-        "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-10-26T13:17:30+00:00"
-    },
-    {
-      "name": "sebastian/resource-operations",
-      "version": "3.0.3",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/resource-operations.git",
-        "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-        "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.0"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "3.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de"
-        }
-      ],
-      "description": "Provides a list of PHP built-in functions that operate on resources",
-      "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-        "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-09-28T06:45:17+00:00"
-    },
-    {
-      "name": "sebastian/type",
-      "version": "2.3.4",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/type.git",
-        "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-        "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^9.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "2.3-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Collection of value objects that represent the types of the PHP type system",
-      "homepage": "https://github.com/sebastianbergmann/type",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/type/issues",
-        "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2021-06-15T12:49:02+00:00"
-    },
-    {
-      "name": "sebastian/version",
-      "version": "3.0.2",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sebastianbergmann/version.git",
-        "reference": "c6c1022351a901512170118436c764e473f6de8c"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-        "reference": "c6c1022351a901512170118436c764e473f6de8c",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.3"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "3.0-dev"
-        }
-      },
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Sebastian Bergmann",
-          "email": "sebastian@phpunit.de",
-          "role": "lead"
-        }
-      ],
-      "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-      "homepage": "https://github.com/sebastianbergmann/version",
-      "support": {
-        "issues": "https://github.com/sebastianbergmann/version/issues",
-        "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/sebastianbergmann",
-          "type": "github"
-        }
-      ],
-      "time": "2020-09-28T06:39:44+00:00"
-    },
-    {
-      "name": "symfony/polyfill-ctype",
-      "version": "v1.23.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/symfony/polyfill-ctype.git",
-        "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-        "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-        "shasum": ""
-      },
-      "require": {
-        "php": ">=7.1"
-      },
-      "suggest": {
-        "ext-ctype": "For best performance"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-main": "1.23-dev"
-        },
-        "thanks": {
-          "name": "symfony/polyfill",
-          "url": "https://github.com/symfony/polyfill"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Symfony\\Polyfill\\Ctype\\": ""
-        },
-        "files": [
-          "bootstrap.php"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Gert de Pagter",
-          "email": "BackEndTea@gmail.com"
-        },
-        {
-          "name": "Symfony Community",
-          "homepage": "https://symfony.com/contributors"
-        }
-      ],
-      "description": "Symfony polyfill for ctype functions",
-      "homepage": "https://symfony.com",
-      "keywords": [
-        "compatibility",
-        "ctype",
-        "polyfill",
-        "portable"
-      ],
-      "support": {
-        "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
-      },
-      "funding": [
-        {
-          "url": "https://symfony.com/sponsor",
-          "type": "custom"
-        },
-        {
-          "url": "https://github.com/fabpot",
-          "type": "github"
-        },
-        {
-          "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-          "type": "tidelift"
-        }
-      ],
-      "time": "2021-02-19T12:13:01+00:00"
-    },
-    {
-      "name": "theseer/tokenizer",
-      "version": "1.2.1",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/theseer/tokenizer.git",
-        "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-        "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
-        "shasum": ""
-      },
-      "require": {
-        "ext-dom": "*",
-        "ext-tokenizer": "*",
-        "ext-xmlwriter": "*",
-        "php": "^7.2 || ^8.0"
-      },
-      "type": "library",
-      "autoload": {
-        "classmap": [
-          "src/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "BSD-3-Clause"
-      ],
-      "authors": [
-        {
-          "name": "Arne Blankerts",
-          "email": "arne@blankerts.de",
-          "role": "Developer"
-        }
-      ],
-      "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-      "support": {
-        "issues": "https://github.com/theseer/tokenizer/issues",
-        "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
-      },
-      "funding": [
-        {
-          "url": "https://github.com/theseer",
-          "type": "github"
-        }
-      ],
-      "time": "2021-07-28T10:34:58+00:00"
-    },
-    {
-      "name": "webmozart/assert",
-      "version": "1.10.0",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/webmozarts/assert.git",
-        "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
-        "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
-        "shasum": ""
-      },
-      "require": {
-        "php": "^7.2 || ^8.0",
-        "symfony/polyfill-ctype": "^1.8"
-      },
-      "conflict": {
-        "phpstan/phpstan": "<0.12.20",
-        "vimeo/psalm": "<4.6.1 || 4.6.2"
-      },
-      "require-dev": {
-        "phpunit/phpunit": "^8.5.13"
-      },
-      "type": "library",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "1.10-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Webmozart\\Assert\\": "src/"
-        }
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Bernhard Schussek",
-          "email": "bschussek@gmail.com"
-        }
-      ],
-      "description": "Assertions to validate method input/output with nice error messages.",
-      "keywords": [
-        "assert",
-        "check",
-        "validate"
-      ],
-      "support": {
-        "issues": "https://github.com/webmozarts/assert/issues",
-        "source": "https://github.com/webmozarts/assert/tree/1.10.0"
-      },
-      "time": "2021-03-09T10:59:23+00:00"
-    }
-  ],
-  "aliases": [],
-  "minimum-stability": "stable",
-  "stability-flags": [],
-  "prefer-stable": false,
-  "prefer-lowest": false,
-  "platform": {
-    "php": "^7.3",
-    "ext-dom": "*",
-    "ext-json": "*",
-    "ext-mbstring": "*",
-    "ext-openssl": "*"
-  },
-  "platform-dev": [],
-  "plugin-api-version": "2.1.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.2.0"
 }

--- a/web/index.php
+++ b/web/index.php
@@ -64,6 +64,8 @@ $container->share(FilesystemInterface::class, function () use ($request) {
 
     $graph = new \EasyRdf_Graph();
 
+    \EasyRdf_Namespace::set('lm', 'https://purl.org/pdsinterop/link-metadata#');
+
 	// Create Formats objects
 	$formats = new \Pdsinterop\Rdf\Formats();
 


### PR DESCRIPTION
This MR adds support for Solid Link Metadata as proposed in [pdsinterop/solid-link-metadata](https://github.com/pdsinterop/solid-link-metadata/).

The functionality itself is provided by the `pdsinterop/solid-crud` and `pdsinterop/flysystem-rdf` packages, hence only a dependency update is needed.